### PR TITLE
Move `electrical` package to `metrics.electrical`

### DIFF
--- a/proto/frequenz/api/common/metrics/electrical.proto
+++ b/proto/frequenz/api/common/metrics/electrical.proto
@@ -8,7 +8,7 @@
 
 syntax = "proto3";
 
-package frequenz.api.common.electrical;
+package frequenz.api.common.metrics.electrical;
 
 import "frequenz/api/common/metrics.proto";
 

--- a/py/frequenz/api/common/__init__.py
+++ b/py/frequenz/api/common/__init__.py
@@ -1,4 +1,4 @@
-"""Frequenz Common API definitions.
+# License: MIT
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
-Copyright © 2023 Frequenz Energy-as-a-Service GmbH.
-"""
+"""Frequenz Common API definitions."""

--- a/py/frequenz/api/common/metrics/__init__.py
+++ b/py/frequenz/api/common/metrics/__init__.py
@@ -1,0 +1,4 @@
+# License: MIT
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
+
+"""Frequenz Common API definitions for metrics."""

--- a/pytests/test_common.py
+++ b/pytests/test_common.py
@@ -41,11 +41,11 @@ def test_module_import_metrics() -> None:
 def test_module_import_metrics_electrical() -> None:
     """Test that the modules can be imported."""
     # pylint: disable=import-outside-toplevel
-    from frequenz.api.common import electrical_pb2
+    from frequenz.api.common.metrics import electrical_pb2
 
     assert electrical_pb2 is not None
 
     # pylint: disable=import-outside-toplevel
-    from frequenz.api.common import electrical_pb2_grpc
+    from frequenz.api.common.metrics import electrical_pb2_grpc
 
     assert electrical_pb2_grpc is not None


### PR DESCRIPTION
Also fix the `components` package name and add a missing `syntax` to the `metrics` package.