### PR TITLE
Use HTTPS URL for the submodule

### DIFF
--- a/.github/RELEASE_NOTES.template.md
+++ b/.github/RELEASE_NOTES.template.md
@@ -1,4 +1,4 @@
-# Frequenz Migrogrid API Release Notes
+# Frequenz Common API Release Notes
 
 ## Summary
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "submodules/api-common-protos"]
 	path = submodules/api-common-protos
-	url = git@github.com:googleapis/api-common-protos.git
+	url = https://github.com/googleapis/api-common-protos.git

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,14 @@
 
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including if there are any depractions and what they should be replaced with --> 
+* The submodule URL was changed to use HTTPS instead of SSH (to avoid problems trying to unlock SSH keys to do updates, etc.).
+
+  Make sure you sync your submodules to the new URL:
+
+  ```console
+  $ git submodule sync
+  Synchronizing submodule url for 'submodules/api-common-protos'
+  ```
 
 ## New Features
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,5 +2,16 @@
 
 ## Summary
 
-- Various build system fixes
-- Improved smoothness of using this as a dependency
+<!-- Here goes a general summary of what this release is about -->
+
+## Upgrading
+
+<!-- Here goes notes on how to upgrade from previous versions, including if there are any depractions and what they should be replaced with --> 
+
+## New Features
+
+<!-- Here goes the main new features and examples or instructions on how to use them -->
+
+## Bug Fixes
+
+<!-- Here goes notable bug fixes that are worth a special mention or explanation -->


### PR DESCRIPTION
- Fix RELEASE_NOTES template
- Clear release notes
- Use HTTPS to retrieve the submodule
