### PR TITLE
Configure the protobuf include paths

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,9 @@ profile = "black"
 line_length = 88
 src_paths = ["benchmarks", "examples", "src", "tests"]
 
+[tool.frequenz-repo-config.protobuf]
+include_paths = ["submodules/api-common-protos"]
+
 [tool.pylint.similarities]
 ignore-comments = ['yes']
 ignore-docstrings = ['yes']


### PR DESCRIPTION
By default repo-config adds this repository (api-common) as a dependency when generating new API repos, as it is supposed to be included by most (if not all) APIs. So the default `include_paths` repo-config uses looks like `["submodules/api-common-protos", "submodules/frequenz-api-common/proto"]`.

Of course in this repository we don't have ourself as a cyclic dependency, and we only depend on `submodules/api-common-protos`, so we need to override the `include_paths` option, otherwise we get errors about `submodules/frequenz-api-common/proto` not existing.