### PR TITLE
Revert "Update protobuf file headers"

### DIFF
--- a/proto/frequenz/api/common/components.proto
+++ b/proto/frequenz/api/common/components.proto
@@ -1,9 +1,10 @@
 // Frequenz microgrid components definitions.
 //
+// Copyright:
 // Copyright 2023 Frequenz Energy-as-a-Service GmbH
 //
-// Licensed under the MIT License (the "License");
-// you may not use this file except in compliance with the License.
+// License:
+// MIT
 
 syntax = "proto3";
 

--- a/proto/frequenz/api/common/metrics.proto
+++ b/proto/frequenz/api/common/metrics.proto
@@ -1,9 +1,10 @@
 // Metrics & bounds definitions.
 //
+// Copyright:
 // Copyright 2023 Frequenz Energy-as-a-Service GmbH
 //
-// Licensed under the MIT License (the "License");
-// you may not use this file except in compliance with the License.
+// License:
+// MIT
 
 syntax = "proto3";
 

--- a/proto/frequenz/api/common/metrics/electrical.proto
+++ b/proto/frequenz/api/common/metrics/electrical.proto
@@ -1,9 +1,10 @@
 // Contains definitions for electrical metrics (AC and DC).
 //
+// Copyright:
 // Copyright 2023 Frequenz Energy-as-a-Service GmbH
 //
-// Licensed under the MIT License (the "License");
-// you may not use this file except in compliance with the License.
+// License:
+// MIT
 
 syntax = "proto3";
 


### PR DESCRIPTION
The update was not necessary, the original request for a header change came from a other repository which had a bad license header and didn't take into account the current standard format set in the `repo-config` cookiecutter templates.

This reverts commit d1043330fed9b0c070140224c64ca6754d166252.
