### PR TITLE
Add country code to the Location message

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,7 +11,7 @@
 ## New Features
 
 * Added a new message named `Location`, representing the co-ordinates of a
-  geographical location.
+  geographical location and the corresponding country-code.
 
 * Added a new variant `COMPONENT_CATEGORY_RELAY` to the `ComponentCategory`
   enum.

--- a/proto/frequenz/api/common/location.proto
+++ b/proto/frequenz/api/common/location.proto
@@ -16,4 +16,7 @@ message Location {
 
   // Longitude ranges from -180 (West) to 180 (East)
   float longitude = 2;
+
+  // Country ISO 3166-1 Alpha 2
+  string country_code = 3;
 }


### PR DESCRIPTION
Some control parameters change depending upon the country of the microgrid. While the country code can be derived from the geo-coordinates, it is better to expose it via our APIs, so that the behaviour of obtaining the codes is more consistent, and clients do not need to worry about it.

closes #52 