### PR TITLE
Upgrade to repo-config v0.5.2

### DIFF
--- a/.cookiecutter-replay.json
+++ b/.cookiecutter-replay.json
@@ -13,17 +13,6 @@
     "pypi_package_name": "frequenz-api-common",
     "github_repo_name": "frequenz-api-common",
     "default_codeowners": "@frequenz-floss/api-team",
-    "_extensions": [
-      "jinja2_time.TimeExtension",
-      "local_extensions.as_identifier",
-      "local_extensions.default_codeowners",
-      "local_extensions.github_repo_name",
-      "local_extensions.keywords",
-      "local_extensions.pypi_package_name",
-      "local_extensions.python_package",
-      "local_extensions.src_path",
-      "local_extensions.title"
-    ],
     "_template": "gh:frequenz-floss/frequenz-repo-config-python"
   }
 }

--- a/.cookiecutter-replay.json
+++ b/.cookiecutter-replay.json
@@ -1,5 +1,6 @@
 {
   "cookiecutter": {
+    "Introduction": "",
     "type": "api",
     "name": "common",
     "description": "Frequenz common gRPC API and bindings",

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,26 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# Set default charset, indent style and trimming of whitespace
+[{.editorconfig,CODEOWNERS,LICENSE,*.{in,json,md,proto,py,pyi,toml,yaml,yml}}]
+charset = utf-8
+indent_style = space
+trim_trailing_whitespace = true
+
+# 4 space indentation
+[*.{py,pyi}]
+indent_size = 4
+
+# 2 space indentation
+[{.editorconfig,CODEOWNERS,LICENSE,*.{in,json,proto,toml,yaml,yml}}]
+indent_size = 2
+
+# No indentation size specified for *.md because different blocks have
+# different indentation rules

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -13,6 +13,7 @@
   - LICENSE
 
 "part:tests":
+  - "**/conftest.py"
   - "pytests/**"
 
 "part:tooling":
@@ -20,6 +21,7 @@
   - "**/*.toml"
   - "**/*.yaml"
   - "**/*.yml"
+  - "**/conftest.py"
   - ".editorconfig"
   - ".git*"
   - ".git*/**"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -20,6 +20,7 @@
   - "**/*.toml"
   - "**/*.yaml"
   - "**/*.yml"
+  - ".editorconfig"
   - ".git*"
   - ".git*/**"
   - "docs/*.py"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,6 +60,8 @@ jobs:
     steps:
       - name: Fetch sources
         uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -84,6 +86,8 @@ jobs:
     steps:
       - name: Fetch sources
         uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -113,6 +117,8 @@ jobs:
     steps:
       - name: Fetch sources
         uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Setup Git user and e-mail
         uses: frequenz-floss/setup-git-user@v2
@@ -190,6 +196,8 @@ jobs:
       - name: Fetch sources
         if: steps.mike-metadata.outputs.version
         uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Setup Git user and e-mail
         if: steps.mike-metadata.outputs.version

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -21,3 +21,4 @@ jobs:
         uses: actions/labeler@ac9175f8a1f3625fd0d4fb234536d26811351594  # 4.3.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          dot: true

--- a/.github/workflows/release-notes-check.yml
+++ b/.github/workflows/release-notes-check.yml
@@ -1,0 +1,28 @@
+name: Release Notes Check
+
+on:
+  merge_group:
+  pull_request:
+    types:
+      # On by default if you specify no types.
+      - "opened"
+      - "reopened"
+      - "synchronize"
+      # For `skip-label` only.
+      - "labeled"
+      - "unlabeled"
+
+
+jobs:
+  check-release-notes:
+    name: Check release notes are updated
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for a release notes update
+        if: github.event_name == 'pull_request'
+        uses: brettcannon/check-for-changed-files@4170644959a21843b31f1181f2a1761d65ef4791 # v1.2.0
+        with:
+          file-pattern: "RELEASE_NOTES.md"
+          prereq-pattern: "{proto,py}/**"
+          skip-label: "cmd:skip-release-notes"
+          failure-message: "Missing a release notes update. Please add one or apply the ${skip-label} label to the pull request"

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,15 @@
+exclude .cookiecutter-replay.json
+exclude .darglint
 exclude .editorconfig
 exclude .gitignore
 exclude .gitmodules
+exclude CODEOWNERS
+exclude CONTRIBUTING.md
+exclude mkdocs.yml
 exclude noxfile.py
 exclude src/conftest.py
 recursive-exclude .github *
+recursive-exclude docs *
 recursive-exclude pytests *
 recursive-include py *.pyi
-recursive-include submodules/api-common-protos/google *.proto
+recursive-include submodules *.proto

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ exclude .editorconfig
 exclude .gitignore
 exclude .gitmodules
 exclude noxfile.py
+exclude src/conftest.py
 recursive-exclude .github *
 recursive-exclude pytests *
 recursive-include py *.pyi

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+exclude .editorconfig
 exclude .gitignore
 exclude .gitmodules
 exclude noxfile.py

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -103,6 +103,7 @@ plugins:
             show_root_members_full_path: true
             show_source: true
           import:
+            # See https://mkdocstrings.github.io/python/usage/#import for details
             - https://docs.python.org/3/objects.inv
             - https://grpc.github.io/grpc/python/objects.inv
             - https://typing-extensions.readthedocs.io/en/stable/objects.inv

--- a/py/conftest.py
+++ b/py/conftest.py
@@ -1,0 +1,13 @@
+# License: MIT
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
+
+"""Validate docstring code examples.
+
+Code examples are often wrapped in triple backticks (```) within docstrings.
+This plugin extracts these code examples and validates them using pylint.
+"""
+
+from frequenz.repo.config.pytest import examples
+from sybil import Sybil
+
+pytest_collect_file = Sybil(**examples.get_sybil_arguments()).pytest()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@
 requires = [
   "setuptools == 67.7.2",
   "setuptools_scm[toml] == 7.1.0",
-  "frequenz-repo-config[api] == 0.4.0",
+  "frequenz-repo-config[api] == 0.5.2",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -49,14 +49,14 @@ dev-mkdocs = [
   "mkdocs-material == 9.1.21",
   "mkdocs-section-index == 0.3.5",
   "mkdocstrings[python] == 0.22.0",
-  "frequenz-repo-config[api] == 0.4.0",
+  "frequenz-repo-config[api] == 0.5.2",
 ]
 dev-mypy = [
   "mypy == 1.5.1",
   # For checking the noxfile, docs/ script, and tests
   "frequenz-api-common[dev-mkdocs,dev-noxfile,dev-pytest]",
 ]
-dev-noxfile = ["nox == 2023.4.22", "frequenz-repo-config[api] == 0.4.0"]
+dev-noxfile = ["nox == 2023.4.22", "frequenz-repo-config[api] == 0.5.2"]
 dev-pylint = [
   "pylint == 2.17.5",
   # For checking the noxfile, docs/ script, and tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,10 @@ dev-pylint = [
   # For checking the noxfile, docs/ script, and tests
   "frequenz-api-common[dev-mkdocs,dev-noxfile,dev-pytest]",
 ]
-dev-pytest = ["pytest == 7.4.0"]
+dev-pytest = [
+  "pytest == 7.4.0",
+  "frequenz-repo-config[extra-lint-examples] == 0.5.2",
+]
 dev = [
   "frequenz-api-common[dev-mkdocs,dev-docstrings,dev-formatting,dev-mkdocs,dev-mypy,dev-noxfile,dev-pylint,dev-pytest]",
 ]


### PR DESCRIPTION
All the changes are related to regenerating the files using the cookiecutter templates in repo-config v0.5.2.

- Remove extensions from replay file
- Remove unused `Introduction` from the replay file
- Bump repo-config version to v0.5.2
- Add editorconfig file
- Collect and test code examples in docstrings
- ci: Check out submodules
- labeler: Include dotfiles in match expressions
- Add comment to get more details about cross-referencing
- Add a workflow to make sure release notes are updated
- Don't ship development files in the source distribution
- Bump setuptools dependency
