### PR TITLE
Rename `PRECHARGE_MODULE` to `PRECHARGER`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,6 +15,9 @@
   `COMPONENT_CATEGORY_SENSOR` and the enum `SensorType` from
   `frequenz.api.common.components`.
 
+- The component category variant `PRECHARGE_MODULE` has been renamed to
+  `PRECHARGER`.
+
 ## New Features
 
 - Added a new component category variant: `COMPONENT_CATEGORY_FUSE`.

--- a/proto/frequenz/api/common/v1/components.proto
+++ b/proto/frequenz/api/common/v1/components.proto
@@ -56,7 +56,7 @@ enum ComponentCategory {
   // While many inverters and batteries come equipped with in-built precharging
   // mechanisms, some may lack this feature. In such cases, we need to use
   // external precharging modules.
-  COMPONENT_CATEGORY_PRECHARGE_MODULE = 12;
+  COMPONENT_CATEGORY_PRECHARGER = 12;
 
   // A fuse.
   // Fuses are used to protect electrical components from overcurrents.


### PR DESCRIPTION
This is done to maintain consistency with the naming of other component categories, none of which contain the word "module".