### PR TITLE
Add new sensor category and metric enums

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,11 @@
   `frequenz.api.common.v1.<package>`. `v1` is the API's major version, and will
   be incremented for breaking changes.
 
+- Added `frequenz.api.common.sensors` package, containing the enums
+  `SensorCategory` and `SensorType`. Removed the component category variant
+  `COMPONENT_CATEGORY_SENSOR` and the enum `SensorType` from
+  `frequenz.api.common.components`.
+
 ## New Features
 
 <!-- Here goes the main new features and examples or instructions on how to use them -->

--- a/proto/frequenz/api/common/v1/components.proto
+++ b/proto/frequenz/api/common/v1/components.proto
@@ -34,9 +34,6 @@ enum ComponentCategory {
   // A station for charging electrical vehicles.
   COMPONENT_CATEGORY_EV_CHARGER = 6;
 
-  // A sensor for measuring ambient metrics, e.g., temperature, humidity, etc.
-  COMPONENT_CATEGORY_SENSOR = 7;
-
   // A crypto miner.
   COMPONENT_CATEGORY_CRYPTO_MINER = 8;
 
@@ -102,31 +99,4 @@ enum EvChargerType {
 
   // The EV charging station supports both AC and DC.
   EV_CHARGER_TYPE_HYBRID = 3;
-}
-
-// Enumerated sensor types.
-enum SensorType {
-  // Unspecified
-  SENSOR_TYPE_UNSPECIFIED = 0;
-
-  // Thermometer (temperature sensor)
-  SENSOR_TYPE_THERMOMETER = 1;
-
-  // Hygrometer (humidity sensor)
-  SENSOR_TYPE_HYGROMETER = 2;
-
-  // Barometer (pressure sensor).
-  SENSOR_TYPE_BAROMETER = 3;
-
-  // Pyranometer (solar irradiance sensor).
-  SENSOR_TYPE_PYRANOMETER = 4;
-
-  // Anemometer (wind velocity and direction sensor).
-  SENSOR_TYPE_ANEMOMETER = 5;
-
-  // Accelerometers (acceleration sensor).
-  SENSOR_TYPE_ACCELEROMETER = 6;
-
-  // General sensors, which do not fall in any of the above categories
-  SENSOR_TYPE_GENERAL = 7;
 }

--- a/proto/frequenz/api/common/v1/sensors.proto
+++ b/proto/frequenz/api/common/v1/sensors.proto
@@ -1,0 +1,78 @@
+// Frequenz microgrid sensor definitions.
+//
+// Copyright:
+// Copyright 2023 Frequenz Energy-as-a-Service GmbH
+//
+// License:
+// MIT
+
+syntax = "proto3";
+
+package frequenz.api.common.v1.sensors;
+
+// Enumerated sensor categories.
+enum SensorCategory {
+  // Unspecified
+  SENSOR_CATEGORY_UNSPECIFIED = 0;
+
+  // Thermometer (temperature sensor)
+  SENSOR_CATEGORY_THERMOMETER = 1;
+
+  // Hygrometer (humidity sensor)
+  SENSOR_CATEGORY_HYGROMETER = 2;
+
+  // Barometer (pressure sensor).
+  SENSOR_CATEGORY_BAROMETER = 3;
+
+  // Pyranometer (solar irradiance sensor).
+  SENSOR_CATEGORY_PYRANOMETER = 4;
+
+  // Anemometer (wind velocity and direction sensor).
+  SENSOR_CATEGORY_ANEMOMETER = 5;
+
+  // Accelerometers (acceleration sensor).
+  SENSOR_CATEGORY_ACCELEROMETER = 6;
+
+  // General sensors, which do not fall in any of the above categories
+  SENSOR_CATEGORY_GENERAL = 7;
+}
+
+// Enumrated sensor metrics.
+enum SensorMetric {
+  // Unspecified.
+  SENSOR_METRIC_UNSPECIFIED = 0;
+
+  // Temperature.
+  // In Celsius (°C).
+  SENSOR_METRIC_TEMPERATURE = 1;
+
+  // Humidity
+  // In percentage (%).
+  SENSOR_METRIC_HUMIDITY = 2;
+
+  // Pressure
+  // In Pascal (Pa).
+  SENSOR_METRIC_PRESSURE = 3;
+
+  // Irradiance / Radiation flux
+  // In watts per square meter (W / m^2).
+  SENSOR_METRIC_IRRADIANCE = 4;
+
+  // Velocity
+  // In meters per second (m / s).
+  SENSOR_METRIC_VELOCITY = 5;
+
+  // Acceleration.
+  // In meters per second per second (m / s^2)
+  SENSOR_METRIC_ACCELERATION = 6;
+
+  // Metric to represent angles, for metrics like direction.
+  // In angles with respect to the (magnetic) North (°).
+  SENSOR_METRIC_ANGLE = 7;
+
+  // Dew point.
+  // The temperature at which the air becomes saturated with water vapor.
+  //
+  // In Celsius (°C).
+  SENSOR_METRIC_DEW_POINT = 8;
+}


### PR DESCRIPTION
In our terminology, `components` are the devices that are connected to a microgrid's electrical circuit, and `sensors` are the devices that measure the physical parameters of the environment.

Hence, we need to distinguish between the two, and we need to be able to identify the type of sensor and the type of metric that it measures.

This commit adds the `frequenz.api.common.v1.sensors` package, which contains the `SensorCategory` and `SensorMetric` enums.

Also, this commit removes
* the `COMPONENT_CATEGORY_SENSOR` variant from the `ComponentCategory` enum, and
* The `SensorType` enum.