### PR TITLE
Add a message 'Pagination' to define pagination parameters

### DIFF
--- a/proto/frequenz/api/common/v1/pagination.proto
+++ b/proto/frequenz/api/common/v1/pagination.proto
@@ -1,0 +1,43 @@
+// Parameters for pagination.
+//
+// Copyright 2023 Frequenz Energy-as-a-Service GmbH
+//
+// Licensed under the MIT License (the "License");
+// you may not use this file except in compliance with the License.
+
+syntax = "proto3";
+
+package frequenz.api.common.v1.pagination;
+
+// A message defining parameters for paginating list requests.
+// It can be appended to a request message to specify the desired page of
+// results and the maximum number of results per page. For initial requests
+// (requesting the first page), the page_token should not be provided. For
+// subsequent requests (requesting any page after the first), the
+// next_page_token from the previous responses PaginationInfo must be supplied.
+// The page_size should only be specified in the initial request and will be
+// disregarded in subsequent requests.
+message PaginationParams {
+  // The maximum number of results to be returned per request.
+  optional uint32 page_size = 1;
+
+  // The token identifying a specific page of the list results.
+  optional string page_token = 2;
+}
+
+// A message providing metadata about paginated list results.
+// The PaginationInfo message delivers metadata concerning the paginated list
+// results and should be appended to the response message of a list request. The
+// total_items field must be set to the total count of items that adhere to the
+// filter criteria defined in the request. The next_page_token field should be
+// populated with the token to be used in the subsequent request to fetch the
+// next page of results. If there are no additional results, the next_page_token
+// field should be omitted.
+message PaginationInfo {
+  // The total number of items that match the filter criteria defined in the
+  // request.
+  uint32 total_items = 1;
+
+  // Token for retrieving the next set of results.
+  optional string next_page_token = 2;
+}


### PR DESCRIPTION
This message can be utilized in various protobuf specifications for APIs, allowing the request to specify pagination parameters and establish the API's response behavior.

Fixes #98