### PR TITLE
Make lower and upper bounds optional in the Bounds message

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,7 @@
 
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
+- `lower` and `upper` bounds fields in the `Bounds` message are now `optional`
 
 ## New Features
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,26 +2,16 @@
 
 ## Summary
 
-Added versioning to the API, added new component category variants, and split
-sensors out of components.
+<!-- Here goes a general summary of what this release is about -->
 
 ## Upgrading
 
-- The package names have been changed from `frequenz.api.common.<package>` to
-  `frequenz.api.common.v1.<package>`. `v1` is the API's major version, and will
-  be incremented for breaking changes.
-
-- Added `frequenz.api.common.sensors` package, containing the enums
-  `SensorCategory` and `SensorType`. Removed the component category variant
-  `COMPONENT_CATEGORY_SENSOR` and the enum `SensorType` from
-  `frequenz.api.common.components`.
-
-- The component category variant `PRECHARGE_MODULE` has been renamed to
-  `PRECHARGER`.
+<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
 
 ## New Features
 
-- Added a new component category variant: `COMPONENT_CATEGORY_FUSE`.
+<!-- Here goes the main new features and examples or instructions on how to use them -->
 
-- Added a new component category variant:
-  `COMPONENT_CATEGORY_VOLTAGE_TRANSFORMER`.
+## Bug Fixes
+
+<!-- Here goes notable bug fixes that are worth a special mention or explanation -->

--- a/proto/frequenz/api/common/v1/metrics.proto
+++ b/proto/frequenz/api/common/v1/metrics.proto
@@ -14,10 +14,12 @@ package frequenz.api.common.v1.metrics;
 // The units of the bounds are always the same as the related metric.
 message Bounds {
   // The lower bound.
-  float lower = 1;
+  // If absent, there is no lower bound.
+  optional float lower = 1;
 
   // The upper bound.
-  float upper = 2;
+  // If absent, there is no upper bound.
+  optional float upper = 2;
 }
 
 // A metric's value, with optional limits.


### PR DESCRIPTION
The lower and upper bounds in the Bounds message are now optional. If absent, there is no lower or upper bound. This is useful for metrics that are intended to have only one bound.