### PR TITLE
Add messages to stream sensor data

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -38,6 +38,8 @@
 
 - Added a message to represent metrics sampled from components.
 
+- Added a message `SensorData` to represent metrics sampled from sensors.
+
 ## New Features
 
 <!-- Here goes the main new features and examples or instructions on how to use them -->

--- a/proto/frequenz/api/common/v1/components/data.proto
+++ b/proto/frequenz/api/common/v1/components/data.proto
@@ -270,7 +270,7 @@ message ComponentState {
   // The time at which the state was sampled.
   google.protobuf.Timestamp sampled_at = 1;
 
-  // List if states of the microgrid component.
+  // List of states of the microgrid component.
   //
   // !!! note
   //    The list will contain unique members. No state will exist twice in

--- a/proto/frequenz/api/common/v1/metrics.proto
+++ b/proto/frequenz/api/common/v1/metrics.proto
@@ -154,7 +154,7 @@ enum Metric {
   // EV charging station metrics.
   METRIC_EV_CHARGER_TEMPERATURE = 140;
 
-  //General sensor metrics
+  // General sensor metrics
   METRIC_SENSOR_WIND_SPEED = 160;
   METRIC_SENSOR_WIND_DIRECTION = 162;
   METRIC_SENSOR_TEMPERATURE = 163;

--- a/proto/frequenz/api/common/v1/sensors.proto
+++ b/proto/frequenz/api/common/v1/sensors.proto
@@ -12,6 +12,8 @@ package frequenz.api.common.v1.sensors;
 
 import "frequenz/api/common/v1/metrics.proto";
 
+import "google/protobuf/timestamp.proto";
+
 // Enumerated sensor categories.
 enum SensorCategory {
   // Unspecified
@@ -110,4 +112,58 @@ message SensorData {
 
   // List of measurements for a metric of the specific microgrid sensor.
   repeated frequenz.api.common.v1.metrics.MetricSample metric_samples = 2;
+
+  // List of states of a specific microgrid sensor.
+  repeated SensorState states = 3;
+}
+
+// Representation of a sensor state and errors.
+message SensorState {
+  // The time at which the state was sampled.
+  google.protobuf.Timestamp sampled_at = 1;
+
+  // List of states of the microgrid sensor.
+  //
+  // !!! note
+  //    The list will contain unique members. No state will exist twice in
+  //    this list.
+  repeated SensorStateCode states = 2;
+
+  // List of errors for the microgrid sensor.
+  //
+  // !!! note
+  //    This list is expected to have errors if and only if the sensor is in
+  //    an error state.
+  //
+  // !!! note
+  //    The list will contain unique members. No error will exist twice in
+  //    this list.
+  repeated SensorErrorCode errors = 3;
+}
+
+// Enum to represent the various states that a sensor can be in.
+// This enum is unified across all sensor categories for consistency.
+enum SensorStateCode {
+  // Default value when the sensor state is not explicitly set.
+  // This is the zero value of the enum.
+  SENSOR_STATE_CODE_UNSPECIFIED = 0;
+
+  // The sensor is up and running.
+  SENSOR_STATE_CODE_ON = 1;
+
+  // The sensor is in an error state.
+  SENSOR_STATE_CODE_ERROR = 2;
+}
+
+// A representation of all possible errors that can occur in sensors.
+enum SensorErrorCode {
+  // Default value. No specific error is specified.
+  SENSOR_ERROR_CODE_UNSPECIFIED = 0;
+
+  // The sensor is reporting an unknown or an undefined error, and the sender
+  // cannot parse the sensor error to any of the variants below.
+  SENSOR_ERROR_CODE_UNKNOWN = 1;
+
+  // Error indicating an internal error within the sensor.
+  SENSOR_ERROR_CODE_INTERNAL = 2;
 }

--- a/proto/frequenz/api/common/v1/sensors.proto
+++ b/proto/frequenz/api/common/v1/sensors.proto
@@ -10,6 +10,8 @@ syntax = "proto3";
 
 package frequenz.api.common.v1.sensors;
 
+import "frequenz/api/common/v1/metrics.proto";
+
 // Enumerated sensor categories.
 enum SensorCategory {
   // Unspecified
@@ -75,4 +77,37 @@ enum SensorMetric {
   //
   // In Celsius (°C).
   SENSOR_METRIC_DEW_POINT = 8;
+}
+
+// ComponentData message aggregates multiple metrics, operational states, and
+// errors, related to a specific microgrid component.
+//
+// !!! example
+//   Example output of a component data message:
+//   ```
+//    {
+//      component_id: 13,
+//      metric_samples: [
+//        /* list of metrics for multiple timestamps */
+//        {
+//          sampled_at: "2023-10-01T00:00:00Z",
+//          metric: "METRIC_SENSOR_TEMPERATURE",
+//          sample: metric_sample_type: {simple_metric: {value: 23.5},
+//          bounds: {},
+//        },
+//        {
+//          sampled_at: "2023-10-01T00:00:00Z",
+//          metric: "METRIC_SENSOR_RELATIVE_HUMIDITY",
+//          sample: metric_sample_type: {simple_metric: {value: 23.5},
+//          bounds: {},
+//        }
+//      ]
+//    }
+//  ```
+message SensorData {
+  // The ID of the microgrid sensors.
+  uint64 sensor_id = 1;
+
+  // List of measurements for a metric of the specific microgrid sensor.
+  repeated frequenz.api.common.v1.metrics.MetricSample metric_samples = 2;
 }

--- a/proto/frequenz/api/common/v1/sensors.proto
+++ b/proto/frequenz/api/common/v1/sensors.proto
@@ -111,7 +111,7 @@ message SensorData {
   uint64 sensor_id = 1;
 
   // List of measurements for a metric of the specific microgrid sensor.
-  repeated frequenz.api.common.v1.metrics.MetricSample metric_samples = 2;
+  repeated SensorMetricSample metric_samples = 2;
 
   // List of states of a specific microgrid sensor.
   repeated SensorState states = 3;
@@ -138,7 +138,7 @@ message SensorState {
   // !!! note
   //    The list will contain unique members. No error will exist twice in
   //    this list.
-  repeated SensorErrorCode errors = 3;
+  repeated SensorErrorCode errors = 4;
 }
 
 // Enum to represent the various states that a sensor can be in.
@@ -166,4 +166,16 @@ enum SensorErrorCode {
 
   // Error indicating an internal error within the sensor.
   SENSOR_ERROR_CODE_INTERNAL = 2;
+}
+
+// Representation of a sampled sensor metric along with its value.
+message SensorMetricSample {
+  // The UTC timestamp of when the metric was sampled.
+  google.protobuf.Timestamp sampled_at = 1;
+
+  // The metric that was sampled.
+  frequenz.api.common.v1.metrics.Metric metric = 2;
+
+  // The value of the sampled metric.
+  frequenz.api.common.v1.metrics.MetricSampleVariant sample = 3;
 }


### PR DESCRIPTION
This PR adds a new message `SensorData`, which can used by APIs to send and receive data originating from sensors. Such data samples will contain the metric and the value reported by the sensor, and will also contain a state to inform the system if a sensor is in an error state or not.