### PR TITLE
Add "MicrogridComponentIDs" message

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -66,3 +66,8 @@ This release contains
 - Added messages to support pagination in APIs.
 
 - Removed `metrics/electrical.proto`, since it is no longer needed.
+
+## New Features
+
+- Added `MicrogridComponentIDs` message, which groups a microgrid ID together with
+  a list of component IDs.

--- a/proto/frequenz/api/common/v1/microgrid/microgrid.proto
+++ b/proto/frequenz/api/common/v1/microgrid/microgrid.proto
@@ -62,3 +62,12 @@ message Microgrid {
   // The UTC timestamp indicating when the microgrid was initially created.
   google.protobuf.Timestamp create_timestamp = 7;
 }
+
+// A message to link component IDs with their respective microgrid ID.
+message MicrogridComponentIDs {
+  // The ID of the microgrid.
+  uint64 microgrid_id = 1;
+
+  // List of component IDs belonging to this microgrid.
+  repeated uint64 component_ids = 2;
+}


### PR DESCRIPTION
This message is used to group a microgrid ID with a list of component IDs