### PR TITLE
Fix doc examples for `SensorData` and `ComponentData`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,7 @@ dependencies and run `pytest` manually.
 python -m pip install .[dev-pytest]  # included in .[dev] too
 
 # And for example
-pytest tests/test_*.py
+pytest pytests/test_*.py
 ```
 
 Or you can use `nox`:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,8 +1,10 @@
 # Frequenz Common API Release Notes
 
 ## Summary
+This release:
+* Corrects `SensorData` and `ComponentData` doc examples
+  to correctly reflect differences in respective values.
 
-<!-- Here goes a general summary of what this release is about -->
 
 ## Upgrading
 

--- a/proto/frequenz/api/common/v1/microgrid/components/components.proto
+++ b/proto/frequenz/api/common/v1/microgrid/components/components.proto
@@ -208,11 +208,13 @@ message ComponentConnection {
 //        {
 //          sampled_at: "2023-10-01T00:00:00Z",
 //          states: [],
+//          warnings: [],
 //          errors: [],
 //        },
 //        {
 //          sampled_at: "2023-10-01T00:00:00Z",
 //          states: [],
+//          warnings: [],
 //          errors: [],
 //        },
 //      ]

--- a/proto/frequenz/api/common/v1/microgrid/sensors/sensors.proto
+++ b/proto/frequenz/api/common/v1/microgrid/sensors/sensors.proto
@@ -107,29 +107,35 @@ enum SensorMetric {
   SENSOR_METRIC_DEW_POINT = 8;
 }
 
-// ComponentData message aggregates multiple metrics, operational states, and
-// errors, related to a specific microgrid component.
+// SensorData message aggregates multiple metrics, operational states, and
+// errors, related to a specific microgrid sensor.
 //
 // !!! example
 //   Example output of a component data message:
 //   ```
 //    {
-//      component_id: 13,
+//      sensor_id: 13,
 //      metric_samples: [
 //        /* list of metrics for multiple timestamps */
 //        {
 //          sampled_at: "2023-10-01T00:00:00Z",
 //          metric: "METRIC_SENSOR_TEMPERATURE",
 //          sample: metric_sample_type: {simple_metric: {value: 23.5},
-//          bounds: {},
 //        },
 //        {
 //          sampled_at: "2023-10-01T00:00:00Z",
 //          metric: "METRIC_SENSOR_RELATIVE_HUMIDITY",
 //          sample: metric_sample_type: {simple_metric: {value: 23.5},
-//          bounds: {},
 //        }
+//      ],
+//      states: [
+//        {
+//          sampled_at: "2023-10-01T00:00:00Z",
+//          states: [],
+//          errors: [],
+//        },
 //      ]
+//
 //    }
 //  ```
 message SensorData {


### PR DESCRIPTION
`SensorData` docs currently reflect components/`ComponentData`, and `ComponentData` states were missing `warnings` field contained in just `ComponentState`.

PR corrects contained examples in documentation, they now correctly reflect their respective components.