### PR TITLE
Add Energy message for electricity trading markets

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,19 +2,16 @@
 
 ## Summary
 
-This release adds new features, and fixes the documentation of a few messages.
+<!-- Here goes a general summary of what this release is about -->
 
 ## Upgrading
 
-- This release does not contain breaking changes in terms of protobuf definitions.
-  However, when upgrading, applications may need to be adjusted to work with the new additions.
+<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
 
 ## New Features
 
-- Adds ability to specify static bounds in the `Component` message.
-
-- Adds protobuf definition necessary for Electricity Trading (and for Ancillary Services Market).
+<!-- Here goes the main new features and examples or instructions on how to use them -->
 
 ## Bug Fixes
 
-- Fixes `SensorData` and `ComponentData` doc examples to correctly reflect differences in respective values.
+<!-- Here goes notable bug fixes that are worth a special mention or explanation -->

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,7 @@
 
 ## New Features
 
-<!-- Here goes the main new features and examples or instructions on how to use them -->
+- Add a energy message for electricity trading markets
 
 ## Bug Fixes
 

--- a/proto/frequenz/api/common/v1/market/energy.proto
+++ b/proto/frequenz/api/common/v1/market/energy.proto
@@ -1,0 +1,24 @@
+// Frequenz definitions of energy for electricity trading.
+//
+// Copyright 2023 Frequenz Energy-as-a-Service GmbH
+//
+// Licensed under the MIT License (the "License");
+// you may not use this file except in compliance with the License.
+
+syntax = "proto3";
+
+package frequenz.api.common.v1.market;
+
+import "google/type/decimal.proto";
+
+// Represents a single unit of electricity.
+//
+// !!! note
+//     In these trading orders, the unit of energy is denominated in MWh
+//     (Megawatt-hours) as opposed to MW (Megawatts).  MWh is a unit of energy
+//     representing total output over a period, while MW is a unit of power that
+//     represents the rate of energy production or consumption.
+message Energy {
+  // Represents energy unit in Megawatthours (MWh).
+  google.type.Decimal mwh = 1;
+}


### PR DESCRIPTION
This energy type quantizes energy in MWh and is used for api that deal with electricity trading markets.
