### PR TITLE
Add backwards compatibility with v0.3.x

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,3 +3,6 @@
 ## New Features
 
 - Add a energy message for electricity trading markets
+- Add backwards compatibility with v0.3.x
+
+  This release includes the top-level files present in the v0.3.x release, so the Microgrid API v0.15.x can depend on a newer version of the Common API.

--- a/proto/frequenz/api/common/components.proto
+++ b/proto/frequenz/api/common/components.proto
@@ -1,0 +1,132 @@
+// Frequenz microgrid components definitions.
+//
+// Copyright:
+// Copyright 2023 Frequenz Energy-as-a-Service GmbH
+//
+// License:
+// MIT
+
+syntax = "proto3";
+
+package frequenz.api.common.components;
+
+// Enumrated component categories.
+enum ComponentCategory {
+  // An unknown component categories, useful for error handling, and marking
+  // unknown components in a list of components with otherwise known categories.
+  COMPONENT_CATEGORY_UNSPECIFIED = 0;
+
+  // The point where the local microgrid is connected to the grid.
+  COMPONENT_CATEGORY_GRID = 1;
+
+  // A meter, for measuring electrical metrics, e.g., current, voltage, etc.
+  COMPONENT_CATEGORY_METER = 2;
+
+  // An electricity generator, with batteries or solar energy.
+  COMPONENT_CATEGORY_INVERTER = 3;
+
+  // A DC-DC converter.
+  COMPONENT_CATEGORY_CONVERTER = 4;
+
+  // A storage system for electrical energy, used by inverters.
+  COMPONENT_CATEGORY_BATTERY = 5;
+
+  // A station for charging electrical vehicles.
+  COMPONENT_CATEGORY_EV_CHARGER = 6;
+
+  // A sensor for measuring ambient metrics, e.g., temperature, humidity, etc.
+  COMPONENT_CATEGORY_SENSOR = 7;
+
+  // A crypto miner.
+  COMPONENT_CATEGORY_CRYPTO_MINER = 8;
+
+  // An electrolyzer for converting water into hydrogen and oxygen.
+  COMPONENT_CATEGORY_ELECTROLYZER = 9;
+
+  // A heat and power combustion plant (CHP stands for combined heat and power).
+  COMPONENT_CATEGORY_CHP = 10;
+
+  // A relay.
+  // Relays generally have two states: open (connected) and closed
+  // (disconnected).
+  // They are generally placed in front of a component, e.g., an inverter, to
+  // control whether the component is connected to the grid or not.
+  COMPONENT_CATEGORY_RELAY = 11;
+
+  // A precharge module.
+  // Precharging involves gradually ramping up the DC voltage to prevent any
+  // potential damage to sensitive electrical components like capacitors.
+  // While many inverters and batteries come equipped with in-built precharging
+  // mechanisms, some may lack this feature. In such cases, we need to use
+  // external precharging modules.
+  COMPONENT_CATEGORY_PRECHARGE_MODULE = 12;
+}
+
+// Enumerated battery types.
+enum BatteryType {
+  // Unspecified.
+  BATTERY_TYPE_UNSPECIFIED = 0;
+
+  // Li-ion batteries.
+  BATTERY_TYPE_LI_ION = 1;
+
+  // Sodium-ion batteries
+  BATTERY_TYPE_NA_ION = 2;
+}
+
+// Enumerated inverter types.
+enum InverterType {
+  // Unspecified.
+  INVERTER_TYPE_UNSPECIFIED = 0;
+
+  // Battery inverter.
+  INVERTER_TYPE_BATTERY = 1;
+
+  // Solar inverter.
+  INVERTER_TYPE_SOLAR = 2;
+
+  // Hybrid inverter.
+  INVERTER_TYPE_HYBRID = 3;
+}
+
+// Enumerated EV charger types.
+enum EvChargerType {
+  // Default type.
+  EV_CHARGER_TYPE_UNSPECIFIED = 0;
+
+  // The EV charging station supports AC charging only.
+  EV_CHARGER_TYPE_AC = 1;
+
+  // The EV charging station supports DC charging only.
+  EV_CHARGER_TYPE_DC = 2;
+
+  // The EV charging station supports both AC and DC.
+  EV_CHARGER_TYPE_HYBRID = 3;
+}
+
+// Enumerated sensor types.
+enum SensorType {
+  // Unspecified
+  SENSOR_TYPE_UNSPECIFIED = 0;
+
+  // Thermometer (temperature sensor)
+  SENSOR_TYPE_THERMOMETER = 1;
+
+  // Hygrometer (humidity sensor)
+  SENSOR_TYPE_HYGROMETER = 2;
+
+  // Barometer (pressure sensor).
+  SENSOR_TYPE_BAROMETER = 3;
+
+  // Pyranometer (solar irradiance sensor).
+  SENSOR_TYPE_PYRANOMETER = 4;
+
+  // Anemometer (wind velocity and direction sensor).
+  SENSOR_TYPE_ANEMOMETER = 5;
+
+  // Accelerometers (acceleration sensor).
+  SENSOR_TYPE_ACCELEROMETER = 6;
+
+  // General sensors, which do not fall in any of the above categories
+  SENSOR_TYPE_GENERAL = 7;
+}

--- a/proto/frequenz/api/common/location.proto
+++ b/proto/frequenz/api/common/location.proto
@@ -1,0 +1,22 @@
+// Geographical co-ordinates of a place.
+//
+// Copyright 2023 Frequenz Energy-as-a-Service GmbH
+//
+// Licensed under the MIT License (the "License");
+// you may not use this file except in compliance with the License.
+
+syntax = "proto3";
+
+package frequenz.api.common.location;
+
+// A pair of geographical co-ordinates, representing the location of a place.
+message Location {
+  // Latitude ranges from -90 (South) to 90 (North)
+  float latitude = 1;
+
+  // Longitude ranges from -180 (West) to 180 (East)
+  float longitude = 2;
+
+  // Country ISO 3166-1 Alpha 2
+  string country_code = 3;
+}

--- a/proto/frequenz/api/common/metrics.proto
+++ b/proto/frequenz/api/common/metrics.proto
@@ -1,0 +1,178 @@
+// Metrics & bounds definitions.
+//
+// Copyright:
+// Copyright 2023 Frequenz Energy-as-a-Service GmbH
+//
+// License:
+// MIT
+
+syntax = "proto3";
+
+package frequenz.api.common.metrics;
+
+// A set of lower and upper bounds for any metric.
+// The units of the bounds are always the same as the related metric.
+message Bounds {
+  // The lower bound.
+  float lower = 1;
+
+  // The upper bound.
+  float upper = 2;
+}
+
+// A metric's value, with optional limits.
+message Metric {
+  // The current value of the metric.
+  float value = 1;
+
+  // The manufacturer's rated bounds of the metric. This may differ from
+  // `system_bounds` as it does not take into account the current state of the
+  // overall system.
+  Bounds rated_bounds = 2;
+
+  // The current bounds of the metric, as imposed by the component this metric
+  // originates from.
+  Bounds component_bounds = 3;
+
+  // These bounds indicate the range of values that are disallowed for the
+  // metric.
+  // If these bounds for a metric are [`lower`, `upper`], then this metric's
+  // `value` needs to comply with the constraints
+  // `value <= lower` OR `upper <= value`.
+  //
+  // It is important to note that these bounds work together with
+  // `system_inclusion_bounds`.
+  //
+  // E.g., for the system to accept a charge command,
+  // clients need to request power values within the bounds
+  // `[system_inclusion_bounds.lower, system_exclusion_bounds.lower]`.
+  // This means that clients can only request charge commands with values that
+  // are within the `system_inclusion_bounds`, but not within
+  // `system_exclusion_bounds`.
+  // Similarly, for the system to accept a discharge command,
+  // clients need to request power values within the bounds
+  // `[system_exclusion_bounds.upper, system_inclusion_bounds.upper]`.
+  //
+  // The following diagram illustrates the relationship between the bounds.
+  // ```
+  //   inclusion.lower                              inclusion.upper
+  // <-------|============|------------------|============|--------->
+  //                exclusion.lower    exclusion.upper
+  // ```
+  // ---- values here are disallowed and wil be rejected
+  // ==== vales here are allowed and will be accepted
+  Bounds system_exclusion_bounds = 4;
+
+  // These bounds indicate the range of values that are allowed for the metric.
+  // If these bounds for a metric are [`lower`, `upper`], then this metric's
+  // `value` needs to comply with the constraint `lower <= value <= upper`
+  //
+  // It is important to note that these bounds work together with
+  // `system_exclusion_bounds`.
+  //
+  // E.g., for the system to accept a charge command,
+  // clients need to request power values within the bounds
+  // `[system_inclusion_bounds.lower, system_exclusion_bounds.lower]`.
+  // This means that clients can only request charge commands with values that
+  // are within the `system_inclusion_bounds`, but not within
+  // `system_exclusion_bounds`.
+  // Similarly, for the system to accept a discharge command,
+  // clients need to request power values within the bounds
+  // `[system_exclusion_bounds.upper, system_inclusion_bounds.upper]`.
+  //
+  // The following diagram illustrates the relationship between the bounds.
+  // ```
+  //   inclusion.lower                              inclusion.upper
+  // <-------|============|------------------|============|--------->
+  //                exclusion.lower    exclusion.upper
+  // ```
+  // ---- values here are disallowed and wil be rejected
+  // ==== vales here are allowed and will be accepted
+  Bounds system_inclusion_bounds = 5;
+}
+
+// Metrics depicted as a collection of statistical summaries.
+//
+// Useful when a component has to report multiple values for the same metric.
+// E.g., a battery is a collection of several blocks, and each block has a
+// temperature sensor. The battery can report a summary of the values provided
+// by all these sensors, like, min, max, avg, etc., and if possible, the entire
+// array of temperature values.
+message MetricAggregation {
+  // The average value of the metric.
+  float avg = 1;
+
+  // The minimum value of the metric.
+  optional float min = 2;
+
+  // The maximum value of the metric.
+  optional float max = 3;
+
+  // The array of all the metric values.
+  repeated float raw_values = 12;
+
+  // The manufacturer's rated bounds of the metric. This may differ from
+  // `system_bounds` as it does not take into account the current state of the
+  // overall system.
+  frequenz.api.common.metrics.Bounds rated_bounds = 13;
+
+  // The current bounds of the metric, as imposed by the component this metric
+  // originates from.
+  frequenz.api.common.metrics.Bounds component_bounds = 14;
+
+  // These bounds indicate the range of values that are disallowed for the
+  // metric.
+  // If these bounds for a metric are [`lower`, `upper`], then this metric's
+  // `value` needs to comply with the constraints
+  // `value <= lower` OR `upper <= value`.
+  //
+  // It is important to note that these bounds work together with
+  // `system_inclusion_bounds`.
+  //
+  // E.g., for the system to accept a charge command,
+  // clients need to request power values within the bounds
+  // `[system_inclusion_bounds.lower, system_exclusion_bounds.lower]`.
+  // This means that clients can only request charge commands with power values
+  // that are within the `system_inclusion_bounds`, but not within
+  // `system_exclusion_bounds`.
+  // Similarly, for the system to accept a discharge command,
+  // clients need to request power values within the bounds
+  // `[system_exclusion_bounds.upper, system_inclusion_bounds.upper]`.
+  //
+  // The following diagram illustrates the relationship between the bounds.
+  // ```
+  //   inclusion.lower                              inclusion.upper
+  // <-------|============|------------------|============|--------->
+  //                exclusion.lower    exclusion.upper
+  // ```
+  // ---- values here are disallowed and wil be rejected
+  // ==== vales here are allowed and will be accepted
+  frequenz.api.common.metrics.Bounds system_exclusion_bounds = 4;
+
+  // These bounds indicate the range of values that are allowed for the metric.
+  // If these bounds for a metric are [`lower`, `upper`], then this metric's
+  // `value` needs to comply with the constraint `lower <= value <= upper`
+  //
+  // It is important to note that these bounds work together with
+  // `system_exclusion_bounds`.
+  //
+  // E.g., for the system to accept a charge command,
+  // clients need to request power values within the bounds
+  // `[system_inclusion_bounds.lower, system_exclusion_bounds.lower]`.
+  // This means that clients can only request charge commands with power values
+  // that are within the `system_inclusion_bounds`, but not within
+  // `system_exclusion_bounds`.
+  // Similarly, for the system to accept a discharge command,
+  // clients need to request power values within the bounds
+  // `[system_exclusion_bounds.upper, system_inclusion_bounds.upper]`.
+  //
+  // The following diagram illustrates the relationship between the bounds.
+  // ```
+  //   inclusion.lower                              inclusion.upper
+  // <-------|============|------------------|============|--------->
+  //                exclusion.lower    exclusion.upper
+  // ```
+  // ---- values here are disallowed and wil be rejected
+  // ==== vales here are allowed and will be accepted
+  frequenz.api.common.metrics.Bounds system_inclusion_bounds = 5;
+}

--- a/proto/frequenz/api/common/metrics/electrical.proto
+++ b/proto/frequenz/api/common/metrics/electrical.proto
@@ -1,0 +1,199 @@
+// Contains definitions for electrical metrics (AC and DC).
+//
+// Copyright:
+// Copyright 2023 Frequenz Energy-as-a-Service GmbH
+//
+// License:
+// MIT
+
+syntax = "proto3";
+
+package frequenz.api.common.metrics.electrical;
+
+import "frequenz/api/common/metrics.proto";
+
+// Metrics of a DC electrical connection.
+message DC {
+  // The DC voltage across the component.
+  // In Volt (V).
+  metrics.Metric voltage = 1;
+
+  // The DC current flowing away from the grid connection.
+  // In passive sign convention:
+  // +ve current means consumption, away from the grid.
+  // -ve current means supply into the grid.
+  // In Ampere (A).
+  metrics.Metric current = 2;
+
+  // The DC power flowing away from the grid connection.
+  // In passive sign convention:
+  // +ve power means consumption, away from the grid.
+  // -ve power means supply into the grid.
+  // In Watt (W).
+  metrics.Metric power = 3;
+}
+
+// The current state and metrics of the electrical connections to the
+// inverter.
+message AC {
+  // The active energy the inverter is consuming or generating.
+  message ActiveEnergy {
+    // The sum of the consumed and delivered energy.
+    // This is a signed value in passive sign convention: if more energy is
+    // consumed than delivered, this is a -ve number, otherwise +ve.
+    // In Watt-hour (Wh).
+    metrics.Metric energy = 1;
+
+    // The consumed energy.
+    // In Watt-hour (Wh).
+    metrics.Metric energy_consumed = 2;
+
+    // The delivered energy.
+    // In Watt-hour (Wh).
+    metrics.Metric energy_delivered = 3;
+  }
+
+  // The reactive energy the inverter is consuming or generating.
+  message ReactiveEnergy {
+    // The sum of the capacitive and inductive energy.
+    // This is a signed value. If more energy is capacitive than inductive,
+    // this is a -ve number, otherwise +ve.
+    // In Volt-Ampere-hour (VArh).
+    metrics.Metric energy = 1;
+
+    // The capacitive energy.
+    // In Volt-Ampere-hour (VArh).
+    metrics.Metric energy_capacitive = 2;
+
+    // The inductive energy.
+    // In Volt-Ampere-hour (VArh).
+    metrics.Metric energy_inductive = 3;
+  }
+
+  // The harmonics of the fast Fourier transform of the instantaneous values
+  // and its total harmonic distortion.
+  // In percent (%).
+  message Harmonics {
+    float harmonic_1 = 1;
+    float harmonic_2 = 2;
+    float harmonic_3 = 3;
+    float harmonic_4 = 4;
+    float harmonic_5 = 5;
+    float harmonic_6 = 6;
+    float harmonic_7 = 7;
+    float harmonic_8 = 8;
+    float harmonic_9 = 9;
+    float harmonic_10 = 10;
+    float harmonic_11 = 11;
+  }
+
+  // AC metrics of a single phase.
+  message ACPhase {
+    // The AC voltage between the line and the neutral wire.
+    // In Volt (V).
+    metrics.Metric voltage = 1;
+
+    // AC current.
+    // +ve current means consumption, away from the grid.
+    // -ve current means supply into the grid.
+    // In Ampere (A).
+    metrics.Metric current = 2;
+
+    // AC active power.
+    // +ve power means consumption, away from the grid.
+    // -ve power means supply into the grid.
+    // In Watt (W).
+    metrics.Metric power_active = 3;
+
+    // AC reactive power.
+    // +ve power means inductive (leading).
+    // -ve power means capacitive (lagging).
+    // In Volt-Ampere reactive (VAr).
+    metrics.Metric power_reactive = 4;
+
+    // The total apparent energy. A Positive value represents the net apparent
+    // energy supplied to the grid connection, and vice versa.
+    // In Volt-Ampere-hour (VAh).
+    metrics.Metric energy_apparent = 5;
+
+    // The total active energy counters for the underlying component's
+    // consumption and supply.
+    // In Watt-hour (Wh).
+    ActiveEnergy energy_active = 6;
+
+    // The total reactive energy counters for the underlying component's
+    // capacitive and inductive energy values.
+    // In Volt-Ampere reactive hour (VArh).
+    ReactiveEnergy energy_reactive = 7;
+
+    // Harmonics of the instantaneous active power at the component.
+    // In percent (%).
+    Harmonics harmonics_power_active = 8;
+
+    // Total harmonic distortion
+    // of the instantaneous active power at the component.
+    // In percent (%).
+    float thd_power_active = 9;
+  }
+
+  // Overall AC metrics.
+
+  // The AC frequency.
+  // In Hertz (Hz).
+  metrics.Metric frequency = 1;
+
+  // The apparent 3-phase AC current. Positive values represent apparent energy
+  // flowing towards the grid connection, and vice versa.
+  // In Ampere (A).
+  metrics.Metric current = 2;
+
+  // The apparent 3-phase AC power. Positive values represent apparent energy
+  // flowing towards the grid connection, and vice versa.
+  // In Volt-Ampere (VA).
+  metrics.Metric power_apparent = 3;
+
+  // The total active 3-phase AC active power.
+  // +ve power means consumption, away from the grid.
+  // -ve power means supply into the grid.
+  // In Watt (W).
+  metrics.Metric power_active = 4;
+
+  // The reactive 3-phase AC power.
+  // +ve power means capacitive (current leading w.r.t. voltage).
+  // -ve power means inductive (current lagging w.r.t. voltage).
+  // In Volt-Ampere reactive (VAr).
+  metrics.Metric power_reactive = 5;
+
+  // The total 3-phase apparent energy. A positive value represents the net
+  // apparent energy supplied to the grid connection, and vice versa.
+  // In Volt-Ampere-hour (VAh).
+  metrics.Metric energy_apparent = 6;
+
+  // The total 3-phase active energy counters for the underlying component's
+  // consumption and supply.
+  // In Watt-hour (Wh).
+  ActiveEnergy energy_active = 7;
+
+  // The total 3-phase reactive energy counters for the underlying component's
+  // capacitive and inductive energy values.
+  // In Volt-Ampere reactive hour (VArh).
+  // FIXME: ReactiveEnergy says Volt-Ampere-hour (VAh).
+  ReactiveEnergy energy_reactive = 8;
+
+  // The sums of the harmonics
+  // of the instantaneous active power at the component across all 3 phases.
+  Harmonics harmonics_power_active = 9;
+
+  // The sums of the total harmonic distortion
+  // of the instantaneous active power at the component across all 3 phases.
+  float thd_power_active = 10;
+
+  // AC metrics for phase/line 1.
+  ACPhase phase_1 = 11;
+
+  // AC metrics for phase/line 2.
+  ACPhase phase_2 = 12;
+
+  // AC metrics for phase/line 3.
+  ACPhase phase_3 = 13;
+}

--- a/py/frequenz/api/common/metrics/__init__.py
+++ b/py/frequenz/api/common/metrics/__init__.py
@@ -1,0 +1,4 @@
+# License: MIT
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
+
+"""Frequenz Common API definitions for metrics."""

--- a/pytests/test_v0.py
+++ b/pytests/test_v0.py
@@ -1,0 +1,51 @@
+# License: MIT
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
+
+"""Tests for the v0.3.x frequenz.api.common package."""
+
+
+def test_package_import() -> None:
+    """Test that the package can be imported."""
+    # pylint: disable=import-outside-toplevel
+    from frequenz.api import common
+
+    assert common is not None
+
+
+def test_module_import_components() -> None:
+    """Test that the modules can be imported."""
+    # pylint: disable=import-outside-toplevel
+    from frequenz.api.common import components_pb2
+
+    assert components_pb2 is not None
+
+    # pylint: disable=import-outside-toplevel
+    from frequenz.api.common import components_pb2_grpc
+
+    assert components_pb2_grpc is not None
+
+
+def test_module_import_metrics() -> None:
+    """Test that the modules can be imported."""
+    # pylint: disable=import-outside-toplevel
+    from frequenz.api.common import metrics_pb2
+
+    assert metrics_pb2 is not None
+
+    # pylint: disable=import-outside-toplevel
+    from frequenz.api.common import metrics_pb2_grpc
+
+    assert metrics_pb2_grpc is not None
+
+
+def test_module_import_metrics_electrical() -> None:
+    """Test that the modules can be imported."""
+    # pylint: disable=import-outside-toplevel
+    from frequenz.api.common.metrics import electrical_pb2
+
+    assert electrical_pb2 is not None
+
+    # pylint: disable=import-outside-toplevel
+    from frequenz.api.common.metrics import electrical_pb2_grpc
+
+    assert electrical_pb2_grpc is not None


### PR DESCRIPTION
This PR includes the top-level files present in the v0.3.x release, so the Microgrid API v0.15.x can depend on a newer version of the Common API.

When the Microgrid API v0.15.x is phased out we can remove all the files related to v0.3.x from this repository.