### PR TITLE
Add energy metric information

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,3 +8,5 @@ This release adds a new component category `COMPONENT_CATEGORY_HVAC` to the API.
 
 - A new component category `COMPONENT_CATEGORY_HVAC` has been added to the API
   to represent HVAC (Heating, Ventilation, and Air Conditioning) systems.
+
+- Additional information for energy metric

--- a/proto/frequenz/api/common/v1/metrics/metric_sample.proto
+++ b/proto/frequenz/api/common/v1/metrics/metric_sample.proto
@@ -63,6 +63,20 @@ message MetricValueVariant {
 }
 
 // List of supported metrics.
+//
+// !!! note
+// AC energy metrics information:
+//
+// * This energy metric is reported directly from the component, and not a
+//  result of aggregations in our systems. If a component does not have this
+//  metric, this field cannot be populated.
+//
+//  * Components that provide energy metrics reset this metric from time to
+//  time. This behaviour is specific to each component model. E.g., some
+//  components reset it on UTC 00:00:00.
+//
+//  * This energy metric does not specify the timestamp since when the energy
+//  was being accumulated, and therefore can be inconsistent.
 enum Metric {
   // Default value.
   METRIC_UNSPECIFIED = 0;


### PR DESCRIPTION
This is the same additional info as in the [common-client](https://github.com/frequenz-floss/frequenz-client-common-python/pull/39/files).