### PR TITLE
Bump the `protobuf` and `grpcio` versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,9 @@ requires = [
   # sure the code is generated using the minimum supported versions, as older
   # versions can't work with code that was generated with newer versions.
   # https://protobuf.dev/support/cross-version-runtime-guarantee/#backwards
-  "protobuf == 4.25.3",
-  "grpcio-tools == 1.51.1",
-  "grpcio == 1.51.1",
+  "protobuf == 5.28.0",
+  "grpcio-tools == 1.66.1",
+  "grpcio == 1.66.1",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -33,13 +33,14 @@ classifiers = [
 ]
 requires-python = ">= 3.11, < 4"
 dependencies = [
-  # We can't widen beyond 6 because of protobuf cross-version runtime guarantees
+  # We can't widen beyond the current value unless we bump the minimum
+  # requirements too because of protobuf cross-version runtime guarantees:
   # https://protobuf.dev/support/cross-version-runtime-guarantee/#major
-  "protobuf >= 4.25.3, < 6", # Do not widen beyond 6!
+  "protobuf >= 5.28.0, < 7", # Do not widen beyond 7!
   # We couldn't find any document with a spec about the cross-version runtime
   # guarantee for grpcio, so unless we find one in the future, we'll assume
   # major version jumps are not compatible
-  "grpcio >= 1.51.1, < 2", # Do not widen beyond 2!
+  "grpcio >= 1.66.1, < 2", # Do not widen beyond 2!
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
The `protobuf` version 4.25.x will go out of support soon(ish), on 31 Mar 2025. Since we don't need to keep compatibility to any legacy code, we can bump it in advance as a preparation.

https://protobuf.dev/support/version-support/#python
