### PR TITLE
Improve the `Lifetime` message documentation

### DIFF
--- a/proto/frequenz/api/common/v1/microgrid/lifetime.proto
+++ b/proto/frequenz/api/common/v1/microgrid/lifetime.proto
@@ -15,14 +15,27 @@ import "google/protobuf/timestamp.proto";
 // a microgrid asset, such as a component, connection, sensor, or any other
 // entity with a limited operational lifetime.
 //
-// !!! warning "Permanent Deletion"
-//     The `end_timestamp` indicates that the asset has been permanently removed
-//     from the system.
+// It is normally used to track the historical evolution of assets, and it
+// determines the validity period for the asset's data.
 //
+// If the `start_timestamp` is not set, the asset is considered to be in
+// operation since the beginning of the system's operational history.
+//
+// If the `end_timestamp` is not set, the asset is considered to be in
+// operation indefinitely into the future.
+//
+// If the Lifetime message is completely missing, it means both timestamps are
+// not set, which means the asset is considered to be in operation since the
+// beginning of the system's operational history and indefinitely into the
+// future.
 message Lifetime {
   // The timestamp when the asset became operationally active.
+  // If not set, the asset is considered to be in operation since the beginning
+  // of the system's operational history.
   google.protobuf.Timestamp start_timestamp = 1;
 
   // Optional timestamp when the asset's operational activity ceased.
+  // If not set, the asset is considered to be in operation indefinitely into
+  // the future.
   google.protobuf.Timestamp end_timestamp = 2;
 }


### PR DESCRIPTION
Make the specification of what `Lifetime` message is used for as clear and precise as possible.

Fixes #250.
