### PR TITLE
Build source packages with PEP 625 compliant filenames

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,9 @@
 
 [build-system]
 requires = [
-  "setuptools == 68.1.0",
-  "setuptools_scm[toml] == 7.1.0",
-  "frequenz-repo-config[api] == 0.9.2",
+  "setuptools == 75.8.0",
+  "setuptools_scm[toml] == 8.1.0",
+  "frequenz-repo-config[api] == 0.11.0",
   # We need to pin the protobuf, grpcio and  grpcio-tools dependencies to make
   # sure the code is generated using the minimum supported versions, as older
   # versions can't work with code that was generated with newer versions.
@@ -62,7 +62,7 @@ dev-mkdocs = [
   "mkdocs-literate-nav == 0.6.1",
   "mkdocs-material == 9.5.21",
   "mkdocstrings[python] == 0.25.1",
-  "frequenz-repo-config[api] == 0.9.2",
+  "frequenz-repo-config[api] == 0.11.0",
 ]
 dev-mypy = [
   "mypy == 1.10.0",
@@ -70,7 +70,7 @@ dev-mypy = [
   # For checking the noxfile, docs/ script, and tests
   "frequenz-api-common[dev-mkdocs,dev-noxfile,dev-pytest]",
 ]
-dev-noxfile = ["nox == 2024.4.15", "frequenz-repo-config[api] == 0.9.2"]
+dev-noxfile = ["nox == 2024.4.15", "frequenz-repo-config[api] == 0.11.0"]
 dev-pylint = [
   "pylint == 3.1.0",
   # For checking the noxfile, docs/ script, and tests
@@ -78,7 +78,7 @@ dev-pylint = [
 ]
 dev-pytest = [
   "pytest == 8.2.0",
-  "frequenz-repo-config[extra-lint-examples] == 0.9.2",
+  "frequenz-repo-config[extra-lint-examples] == 0.11.0",
 ]
 dev = [
   "frequenz-api-common[dev-mkdocs,dev-flake8,dev-formatting,dev-mkdocs,dev-mypy,dev-noxfile,dev-pylint,dev-pytest]",


### PR DESCRIPTION
We bump `setuptools` (and related dependencies) so the built source packages have PEP 625 compliant filenames. This is required by PyPI:

> In the future, PyPI will require all newly uploaded source distribution filenames to comply with PEP 625. Any source distributions already uploaded will remain in place as-is and do not need to be updated.
>
> Specifically, your recent upload of 'frequenz-api-common-0.6.4.tar.gz' is incompatible with PEP 625 because it does not contain the normalized project name 'frequenz_api_common'.
