### PR TITLE
Rename microgrid.components -> microgrid.electrical_components

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,7 @@
 ## New Features
 
 - Added message linking microgrid and sensor IDs.
+- Rename `components` to `electrical_components` and related messages, fields, enums.
 
 ## Bug Fixes
 

--- a/proto/frequenz/api/common/v1/microgrid/electrical_components/battery.proto
+++ b/proto/frequenz/api/common/v1/microgrid/electrical_components/battery.proto
@@ -8,7 +8,7 @@
 
 syntax = "proto3";
 
-package frequenz.api.common.v1.microgrid.components;
+package frequenz.api.common.v1.microgrid.electrical_components;
 
 // Enumerated battery types.
 enum BatteryType {

--- a/proto/frequenz/api/common/v1/microgrid/electrical_components/electrical_components.proto
+++ b/proto/frequenz/api/common/v1/microgrid/electrical_components/electrical_components.proto
@@ -8,58 +8,58 @@
 
 syntax = "proto3";
 
-package frequenz.api.common.v1.microgrid.components;
+package frequenz.api.common.v1.microgrid.electrical_components;
 
 import "frequenz/api/common/v1/metrics/bounds.proto";
 import "frequenz/api/common/v1/metrics/metric_sample.proto";
-import "frequenz/api/common/v1/microgrid/components/battery.proto";
-import "frequenz/api/common/v1/microgrid/components/ev_charger.proto";
-import "frequenz/api/common/v1/microgrid/components/fuse.proto";
-import "frequenz/api/common/v1/microgrid/components/grid.proto";
-import "frequenz/api/common/v1/microgrid/components/inverter.proto";
-import "frequenz/api/common/v1/microgrid/components/transformer.proto";
+import "frequenz/api/common/v1/microgrid/electrical_components/battery.proto";
+import "frequenz/api/common/v1/microgrid/electrical_components/ev_charger.proto";
+import "frequenz/api/common/v1/microgrid/electrical_components/fuse.proto";
+import "frequenz/api/common/v1/microgrid/electrical_components/grid.proto";
+import "frequenz/api/common/v1/microgrid/electrical_components/inverter.proto";
+import "frequenz/api/common/v1/microgrid/electrical_components/transformer.proto";
 import "frequenz/api/common/v1/microgrid/lifetime.proto";
 
 import "google/protobuf/timestamp.proto";
 
 // Enumrated component categories.
-enum ComponentCategory {
+enum ElectricalComponentCategory {
   // The component category is unspecified. This should not be used.
-  COMPONENT_CATEGORY_UNSPECIFIED = 0;
+  ELECTRICAL_COMPONENT_CATEGORY_UNSPECIFIED = 0;
 
   // The point where the local microgrid is connected to the grid.
-  COMPONENT_CATEGORY_GRID = 1;
+  ELECTRICAL_COMPONENT_CATEGORY_GRID = 1;
 
   // A meter, for measuring electrical metrics, e.g., current, voltage, etc.
-  COMPONENT_CATEGORY_METER = 2;
+  ELECTRICAL_COMPONENT_CATEGORY_METER = 2;
 
   // An electricity generator, with batteries or solar energy.
-  COMPONENT_CATEGORY_INVERTER = 3;
+  ELECTRICAL_COMPONENT_CATEGORY_INVERTER = 3;
 
   // A DC-DC converter.
-  COMPONENT_CATEGORY_CONVERTER = 4;
+  ELECTRICAL_COMPONENT_CATEGORY_CONVERTER = 4;
 
   // A storage system for electrical energy, used by inverters.
-  COMPONENT_CATEGORY_BATTERY = 5;
+  ELECTRICAL_COMPONENT_CATEGORY_BATTERY = 5;
 
   // A station for charging electrical vehicles.
-  COMPONENT_CATEGORY_EV_CHARGER = 6;
+  ELECTRICAL_COMPONENT_CATEGORY_EV_CHARGER = 6;
 
   // A crypto miner.
-  COMPONENT_CATEGORY_CRYPTO_MINER = 8;
+  ELECTRICAL_COMPONENT_CATEGORY_CRYPTO_MINER = 8;
 
   // An electrolyzer for converting water into hydrogen and oxygen.
-  COMPONENT_CATEGORY_ELECTROLYZER = 9;
+  ELECTRICAL_COMPONENT_CATEGORY_ELECTROLYZER = 9;
 
   // A heat and power combustion plant (CHP stands for combined heat and power).
-  COMPONENT_CATEGORY_CHP = 10;
+  ELECTRICAL_COMPONENT_CATEGORY_CHP = 10;
 
   // A relay.
   // Relays generally have two states: open (connected) and closed
   // (disconnected).
   // They are generally placed in front of a component, e.g., an inverter, to
   // control whether the component is connected to the grid or not.
-  COMPONENT_CATEGORY_RELAY = 11;
+  ELECTRICAL_COMPONENT_CATEGORY_RELAY = 11;
 
   // A precharge module.
   // Precharging involves gradually ramping up the DC voltage to prevent any
@@ -67,11 +67,11 @@ enum ComponentCategory {
   // While many inverters and batteries come equipped with in-built precharging
   // mechanisms, some may lack this feature. In such cases, we need to use
   // external precharging modules.
-  COMPONENT_CATEGORY_PRECHARGER = 12;
+  ELECTRICAL_COMPONENT_CATEGORY_PRECHARGER = 12;
 
   // A fuse.
   // Fuses are used to protect electrical components from overcurrents.
-  COMPONENT_CATEGORY_FUSE = 13;
+  ELECTRICAL_COMPONENT_CATEGORY_FUSE = 13;
 
   // A voltage transformer.
   // Voltage transformers are used to step up or step down the voltage, keeping
@@ -79,45 +79,45 @@ enum ComponentCategory {
   // If voltage is stepped up, current is stepped down, and vice versa.
   // Note that voltage transformers have efficiency losses, so the output power
   // is always less than the input power.
-  COMPONENT_CATEGORY_VOLTAGE_TRANSFORMER = 14;
+  ELECTRICAL_COMPONENT_CATEGORY_VOLTAGE_TRANSFORMER = 14;
 
   // An HVAC (Heating, Ventilation, and Air Conditioning) system.
-  COMPONENT_CATEGORY_HVAC = 15;
+  ELECTRICAL_COMPONENT_CATEGORY_HVAC = 15;
 }
 
 // Metadata specific to a microgrid component.
-message ComponentCategoryMetadataVariant {
+message ElectricalComponentCategoryMetadataVariant {
   oneof metadata {
-    frequenz.api.common.v1.microgrid.components.Battery battery = 1;
-    frequenz.api.common.v1.microgrid.components.EvCharger ev_charger = 2;
-    frequenz.api.common.v1.microgrid.components.Fuse fuse = 3;
-    frequenz.api.common.v1.microgrid.components.GridConnectionPoint grid = 4;
-    frequenz.api.common.v1.microgrid.components.Inverter inverter = 5;
-    frequenz.api.common.v1.microgrid.components.VoltageTransformer
+    frequenz.api.common.v1.microgrid.electrical_components.Battery battery = 1;
+    frequenz.api.common.v1.microgrid.electrical_components.EvCharger ev_charger = 2;
+    frequenz.api.common.v1.microgrid.electrical_components.Fuse fuse = 3;
+    frequenz.api.common.v1.microgrid.electrical_components.GridConnectionPoint grid = 4;
+    frequenz.api.common.v1.microgrid.electrical_components.Inverter inverter = 5;
+    frequenz.api.common.v1.microgrid.electrical_components.VoltageTransformer
       voltage_transformer = 6;
   }
 }
 
-// ComponentStatus defines the possible statuses for a component.
+// ElectricalComponentStatus defines the possible statuses for a component.
 //
 // !!! note
 //     The status indicates the status set by the user via the user interface.
 //     The status is not yet included in the Component messages and should be
 //     added.
 //
-enum ComponentStatus {
+enum ElectricalComponentStatus {
   // The status is unspecified. This should not be used.
-  COMPONENT_STATUS_UNSPECIFIED = 0;
+  ELECTRICAL_COMPONENT_STATUS_UNSPECIFIED = 0;
 
   // The component is active.
-  COMPONENT_STATUS_ACTIVE = 1;
+  ELECTRICAL_COMPONENT_STATUS_ACTIVE = 1;
 
   // The component is inactive.
-  COMPONENT_STATUS_INACTIVE = 2;
+  ELECTRICAL_COMPONENT_STATUS_INACTIVE = 2;
 }
 
 // Microgrid electrical component details.
-message Component {
+message ElectricalComponent {
   // The component ID.
   uint64 id = 1;
 
@@ -128,10 +128,10 @@ message Component {
   string name = 3;
 
   // The component category. E.g., Inverter, Battery, etc.
-  ComponentCategory category = 4;
+  ElectricalComponentCategory category = 4;
 
   // The metadata specific to the component category type.
-  ComponentCategoryMetadataVariant category_type = 5;
+  ElectricalComponentCategoryMetadataVariant category_type = 5;
 
   // The component manufacturer.
   string manufacturer = 6;
@@ -140,7 +140,7 @@ message Component {
   string model_name = 7;
 
   // The status of the component.
-  ComponentStatus status = 8;
+  ElectricalComponentStatus status = 8;
 
   // The operational lifetime of the component.
   frequenz.api.common.v1.microgrid.Lifetime operational_lifetime = 9;
@@ -166,10 +166,10 @@ message MetricConfigBounds {
   frequenz.api.common.v1.metrics.Bounds config_bounds = 2;
 }
 
-// ComponentConnection describes a single electrical link between two components
-// within a microgrid, effectively representing the physical wiring as viewed
-// from the grid connection point, if one exists, or from the islanding point,
-// in case of an islanded microgrids.
+// ElectricalComponentConnection describes a single electrical link between two
+// components within a microgrid, effectively representing the physical wiring
+// as viewed from the grid connection point, if one exists, or from the
+// islanding point, in case of an islanded microgrids.
 //
 // !!! note "Physical Representation"
 //     This message is not about data flow but rather about the physical
@@ -189,7 +189,7 @@ message MetricConfigBounds {
 //     tracking the changes over time to a microgrid, providing insights into
 //     when and how the microgrid infrastructure has been modified.
 //
-message ComponentConnection {
+message ElectricalComponentConnection {
   // Unique identifier of the component where the connection originates. This is
   // aligned with the direction of current flow away from the grid connection
   // point, or in case of islands, away from the islanding point.
@@ -203,14 +203,14 @@ message ComponentConnection {
   frequenz.api.common.v1.microgrid.Lifetime operational_lifetime = 3;
 }
 
-// ComponentData message aggregates multiple metrics, operational states, and
-// errors, related to a specific microgrid component.
+// ElectricalComponentData message aggregates multiple metrics, operational
+// states, and errors, related to a specific microgrid component.
 //
 // !!! example
 //   Example output of a component data message:
 //   ```
 //    {
-//      component_id: 13,
+//      ELECTRICAL_component_id: 13,
 //      metric_samples: [
 //        /* list of metrics for multiple timestamps */
 //        {
@@ -243,7 +243,7 @@ message ComponentConnection {
 //      ]
 //    }
 //  ```
-message ComponentData {
+message ElectricalComponentData {
   // The ID of the microgrid component.
   uint64 component_id = 1;
 
@@ -251,213 +251,213 @@ message ComponentData {
   repeated frequenz.api.common.v1.metrics.MetricSample metric_samples = 2;
 
   // List of states of a specific microgrid component.
-  repeated ComponentState states = 3;
+  repeated ElectricalComponentState states = 3;
 }
 
 // Enum to represent the various states that a component can be in.
 // This enum is unified across all component categories for consistency.
-enum ComponentStateCode {
+enum ElectricalComponentStateCode {
   // Default value when the component state is not explicitly set.
   // This is the zero value of the enum.
-  COMPONENT_STATE_CODE_UNSPECIFIED = 0;
+  ELECTRICAL_COMPONENT_STATE_CODE_UNSPECIFIED = 0;
 
   // State when the component is in an unknown or undefined condition.
   // This is used when the sender is unable to classify the component into any
   // other state.
-  COMPONENT_STATE_CODE_UNKNOWN = 1;
+  ELECTRICAL_COMPONENT_STATE_CODE_UNKNOWN = 1;
 
   // State when the component is temporarily unavailable for operation.
-  COMPONENT_STATE_CODE_UNAVAILABLE = 2;
+  ELECTRICAL_COMPONENT_STATE_CODE_UNAVAILABLE = 2;
 
   // State when the component is in the process of switching off.
-  COMPONENT_STATE_CODE_SWITCHING_OFF = 3;
+  ELECTRICAL_COMPONENT_STATE_CODE_SWITCHING_OFF = 3;
 
   // State when the component has successfully switched off.
-  COMPONENT_STATE_CODE_OFF = 4;
+  ELECTRICAL_COMPONENT_STATE_CODE_OFF = 4;
 
   // State when the component is in the process of switching on from an off
   // state.
-  COMPONENT_STATE_CODE_SWITCHING_ON = 5;
+  ELECTRICAL_COMPONENT_STATE_CODE_SWITCHING_ON = 5;
 
   // State when the component is in standby mode, and not immediately ready for
   // immediate operations.
-  COMPONENT_STATE_CODE_STANDBY = 6;
+  ELECTRICAL_COMPONENT_STATE_CODE_STANDBY = 6;
 
   // State when the component is fully operational and ready for use.
-  COMPONENT_STATE_CODE_READY = 7;
+  ELECTRICAL_COMPONENT_STATE_CODE_READY = 7;
 
   // State when the component is actively consuming energy.
-  COMPONENT_STATE_CODE_CHARGING = 8;
+  ELECTRICAL_COMPONENT_STATE_CODE_CHARGING = 8;
 
   // State when the component is actively producing or releasing energy.
-  COMPONENT_STATE_CODE_DISCHARGING = 9;
+  ELECTRICAL_COMPONENT_STATE_CODE_DISCHARGING = 9;
 
   // State when the component is in an error state and may need attention.
-  COMPONENT_STATE_CODE_ERROR = 10;
+  ELECTRICAL_COMPONENT_STATE_CODE_ERROR = 10;
 
   // The Electric Vehicle (EV) charging cable is unplugged from the charging
   // station.
-  COMPONENT_STATE_CODE_EV_CHARGING_CABLE_UNPLUGGED = 20;
+  ELECTRICAL_COMPONENT_STATE_CODE_EV_CHARGING_CABLE_UNPLUGGED = 20;
 
   // The EV charging cable is plugged into the charging station.
-  COMPONENT_STATE_CODE_EV_CHARGING_CABLE_PLUGGED_AT_STATION = 21;
+  ELECTRICAL_COMPONENT_STATE_CODE_EV_CHARGING_CABLE_PLUGGED_AT_STATION = 21;
 
   // The EV charging cable is plugged into the vehicle.
-  COMPONENT_STATE_CODE_EV_CHARGING_CABLE_PLUGGED_AT_EV = 22;
+  ELECTRICAL_COMPONENT_STATE_CODE_EV_CHARGING_CABLE_PLUGGED_AT_EV = 22;
 
   // The EV charging cable is locked at the charging station end, indicating
   // readiness for charging.
-  COMPONENT_STATE_CODE_EV_CHARGING_CABLE_LOCKED_AT_STATION = 23;
+  ELECTRICAL_COMPONENT_STATE_CODE_EV_CHARGING_CABLE_LOCKED_AT_STATION = 23;
 
   // The EV charging cable is locked at the vehicle end, indicating that
   // charging is active.
-  COMPONENT_STATE_CODE_EV_CHARGING_CABLE_LOCKED_AT_EV = 24;
+  ELECTRICAL_COMPONENT_STATE_CODE_EV_CHARGING_CABLE_LOCKED_AT_EV = 24;
 
   // The relay is in an open state, meaning no current can flow through.
-  COMPONENT_STATE_CODE_RELAY_OPEN = 30;
+  ELECTRICAL_COMPONENT_STATE_CODE_RELAY_OPEN = 30;
 
   // The relay is in a closed state, allowing current to flow.
-  COMPONENT_STATE_CODE_RELAY_CLOSED = 31;
+  ELECTRICAL_COMPONENT_STATE_CODE_RELAY_CLOSED = 31;
 
   // The precharger circuit is open, meaning it's not currently active.
-  COMPONENT_STATE_CODE_PRECHARGER_OPEN = 40;
+  ELECTRICAL_COMPONENT_STATE_CODE_PRECHARGER_OPEN = 40;
 
   // The precharger is in a precharging state, preparing the main circuit for
   // activation.
-  COMPONENT_STATE_CODE_PRECHARGER_PRECHARGING = 41;
+  ELECTRICAL_COMPONENT_STATE_CODE_PRECHARGER_PRECHARGING = 41;
 
   // The precharger circuit is closed, allowing full current to flow to the main
   // circuit.
-  COMPONENT_STATE_CODE_PRECHARGER_CLOSED = 42;
+  ELECTRICAL_COMPONENT_STATE_CODE_PRECHARGER_CLOSED = 42;
 }
 
 // A representation of all possible errors that can occur across all component
 // categories.
-enum ComponentErrorCode {
+enum ElectricalComponentErrorCode {
   // Default value. No specific error is specified.
-  COMPONENT_ERROR_CODE_UNSPECIFIED = 0;
+  ELECTRICAL_COMPONENT_ERROR_CODE_UNSPECIFIED = 0;
 
   // The component is reporting an unknown or an undefined error, and the sender
   // cannot parse the component error to any of the variants below.
-  COMPONENT_ERROR_CODE_UNKNOWN = 1;
+  ELECTRICAL_COMPONENT_ERROR_CODE_UNKNOWN = 1;
 
   // Error indicating that the component could not be switched on.
-  COMPONENT_ERROR_CODE_SWITCH_ON_FAULT = 2;
+  ELECTRICAL_COMPONENT_ERROR_CODE_SWITCH_ON_FAULT = 2;
 
   // Error indicating that the component is operating under the minimum rated
   // voltage.
-  COMPONENT_ERROR_CODE_UNDERVOLTAGE = 3;
+  ELECTRICAL_COMPONENT_ERROR_CODE_UNDERVOLTAGE = 3;
 
   // Error indicating that the component is operating over the maximum rated
   //  voltage.
-  COMPONENT_ERROR_CODE_OVERVOLTAGE = 4;
+  ELECTRICAL_COMPONENT_ERROR_CODE_OVERVOLTAGE = 4;
 
   // Error indicating that the component is drawing more current than the
   // maximum rated value.
-  COMPONENT_ERROR_CODE_OVERCURRENT = 5;
+  ELECTRICAL_COMPONENT_ERROR_CODE_OVERCURRENT = 5;
 
   // Error indicating that the component's consumption current is over the
   // maximum rated value during charging.
-  COMPONENT_ERROR_CODE_OVERCURRENT_CHARGING = 6;
+  ELECTRICAL_COMPONENT_ERROR_CODE_OVERCURRENT_CHARGING = 6;
 
   // Error indicating that the component's production current is over the
   // maximum rated value during discharging.
-  COMPONENT_ERROR_CODE_OVERCURRENT_DISCHARGING = 7;
+  ELECTRICAL_COMPONENT_ERROR_CODE_OVERCURRENT_DISCHARGING = 7;
 
   // Error indicating that the component is operating over the maximum rated
   // temperature.
-  COMPONENT_ERROR_CODE_OVERTEMPERATURE = 8;
+  ELECTRICAL_COMPONENT_ERROR_CODE_OVERTEMPERATURE = 8;
 
   // Error indicating that the component is operating under the minimum rated
   // temperature.
-  COMPONENT_ERROR_CODE_UNDERTEMPERATURE = 9;
+  ELECTRICAL_COMPONENT_ERROR_CODE_UNDERTEMPERATURE = 9;
 
   // Error indicating that the component is exposed to high humidity levels over
   // the maximum rated value.
-  COMPONENT_ERROR_CODE_HIGH_HUMIDITY = 10;
+  ELECTRICAL_COMPONENT_ERROR_CODE_HIGH_HUMIDITY = 10;
 
   // Error indicating that the component's fuse has blown.
-  COMPONENT_ERROR_CODE_FUSE_ERROR = 11;
+  ELECTRICAL_COMPONENT_ERROR_CODE_FUSE_ERROR = 11;
 
   // Error indicating that the component's precharge unit has failed.
-  COMPONENT_ERROR_CODE_PRECHARGE_ERROR = 12;
+  ELECTRICAL_COMPONENT_ERROR_CODE_PRECHARGE_ERROR = 12;
 
   // Error indicating plausibility issues within the system involving this
   // component.
-  COMPONENT_ERROR_CODE_PLAUSIBILITY_ERROR = 13;
+  ELECTRICAL_COMPONENT_ERROR_CODE_PLAUSIBILITY_ERROR = 13;
 
   // Error indicating system shutdown due to undervoltage involving this
   // component.
-  COMPONENT_ERROR_CODE_UNDERVOLTAGE_SHUTDOWN = 14;
+  ELECTRICAL_COMPONENT_ERROR_CODE_UNDERVOLTAGE_SHUTDOWN = 14;
 
   // Error indicating unexpected pilot failure in an electric vehicle (EV)
   // component.
-  COMPONENT_ERROR_CODE_EV_UNEXPECTED_PILOT_FAILURE = 15;
+  ELECTRICAL_COMPONENT_ERROR_CODE_EV_UNEXPECTED_PILOT_FAILURE = 15;
 
   // Error indicating fault current detected in the component.
-  COMPONENT_ERROR_CODE_FAULT_CURRENT = 16;
+  ELECTRICAL_COMPONENT_ERROR_CODE_FAULT_CURRENT = 16;
 
   // Error indicating a short circuit detected in the component.
-  COMPONENT_ERROR_CODE_SHORT_CIRCUIT = 17;
+  ELECTRICAL_COMPONENT_ERROR_CODE_SHORT_CIRCUIT = 17;
 
   // Error indicating a configuration error related to the component.
-  COMPONENT_ERROR_CODE_CONFIG_ERROR = 18;
+  ELECTRICAL_COMPONENT_ERROR_CODE_CONFIG_ERROR = 18;
 
   // Error indicating an illegal state requested for the component.
-  COMPONENT_ERROR_CODE_ILLEGAL_COMPONENT_STATE_CODE_REQUESTED = 19;
+  ELECTRICAL_COMPONENT_ERROR_CODE_ILLEGAL_COMPONENT_STATE_CODE_REQUESTED = 19;
 
   // Error indicating that the hardware of the component is inaccessible.
-  COMPONENT_ERROR_CODE_HARDWARE_INACCESSIBLE = 20;
+  ELECTRICAL_COMPONENT_ERROR_CODE_HARDWARE_INACCESSIBLE = 20;
 
   // Error indicating an internal error within the component.
-  COMPONENT_ERROR_CODE_INTERNAL = 21;
+  ELECTRICAL_COMPONENT_ERROR_CODE_INTERNAL = 21;
 
   // Error indicating that the component is unauthorized to perform the
   // last requested action.
-  COMPONENT_ERROR_CODE_UNAUTHORIZED = 22;
+  ELECTRICAL_COMPONENT_ERROR_CODE_UNAUTHORIZED = 22;
 
   // Error indicating electric vehicle (EV) cable was abruptly unplugged from
   // the charging station.
-  COMPONENT_ERROR_CODE_EV_CHARGING_CABLE_UNPLUGGED_FROM_STATION = 40;
+  ELECTRICAL_COMPONENT_ERROR_CODE_EV_CHARGING_CABLE_UNPLUGGED_FROM_STATION = 40;
 
   // Error indicating electric vehicle (EV) cable was abruptly unplugged from
   // the vehicle.
-  COMPONENT_ERROR_CODE_EV_CHARGING_CABLE_UNPLUGGED_FROM_EV = 41;
+  ELECTRICAL_COMPONENT_ERROR_CODE_EV_CHARGING_CABLE_UNPLUGGED_FROM_EV = 41;
 
   // Error indicating electric vehicle (EV) cable lock failure.
-  COMPONENT_ERROR_CODE_EV_CHARGING_CABLE_LOCK_FAILED = 42;
+  ELECTRICAL_COMPONENT_ERROR_CODE_EV_CHARGING_CABLE_LOCK_FAILED = 42;
 
   // Error indicating an invalid electric vehicle (EV) cable.
-  COMPONENT_ERROR_CODE_EV_CHARGING_CABLE_INVALID = 43;
+  ELECTRICAL_COMPONENT_ERROR_CODE_EV_CHARGING_CABLE_INVALID = 43;
 
   // Error indicating an incompatible electric vehicle (EV) plug.
-  COMPONENT_ERROR_CODE_EV_CONSUMER_INCOMPATIBLE = 44;
+  ELECTRICAL_COMPONENT_ERROR_CODE_EV_CONSUMER_INCOMPATIBLE = 44;
 
   // Error indicating a battery system imbalance.
-  COMPONENT_ERROR_CODE_BATTERY_IMBALANCE = 50;
+  ELECTRICAL_COMPONENT_ERROR_CODE_BATTERY_IMBALANCE = 50;
 
   // Error indicating a low state of health (SOH) detected in the battery.
-  COMPONENT_ERROR_CODE_BATTERY_LOW_SOH = 51;
+  ELECTRICAL_COMPONENT_ERROR_CODE_BATTERY_LOW_SOH = 51;
 
   // Error indicating a battery block error.
-  COMPONENT_ERROR_CODE_BATTERY_BLOCK_ERROR = 52;
+  ELECTRICAL_COMPONENT_ERROR_CODE_BATTERY_BLOCK_ERROR = 52;
 
   // Error indicating a battery controller error.
-  COMPONENT_ERROR_CODE_BATTERY_CONTROLLER_ERROR = 53;
+  ELECTRICAL_COMPONENT_ERROR_CODE_BATTERY_CONTROLLER_ERROR = 53;
 
   // Error indicating a battery relay error.
-  COMPONENT_ERROR_CODE_BATTERY_RELAY_ERROR = 54;
+  ELECTRICAL_COMPONENT_ERROR_CODE_BATTERY_RELAY_ERROR = 54;
 
   // Error indicating that battery calibration is needed.
-  COMPONENT_ERROR_CODE_BATTERY_CALIBRATION_NEEDED = 56;
+  ELECTRICAL_COMPONENT_ERROR_CODE_BATTERY_CALIBRATION_NEEDED = 56;
 
   // Error indicating that the relays have been cycled for the maximum number of
   // times.
-  COMPONENT_ERROR_CODE_RELAY_CYCLE_LIMIT_REACHED = 60;
+  ELECTRICAL_COMPONENT_ERROR_CODE_RELAY_CYCLE_LIMIT_REACHED = 60;
 }
 
 // Representation of a component state and errors.
-message ComponentState {
+message ElectricalComponentState {
   // The time at which the state was sampled.
   google.protobuf.Timestamp sampled_at = 1;
 
@@ -466,7 +466,7 @@ message ComponentState {
   // !!! note
   //    The list will contain unique members. No state will exist twice in
   //    this list.
-  repeated ComponentStateCode states = 2;
+  repeated ElectricalComponentStateCode states = 2;
 
   // List of warnings for the microgrid component.
   //
@@ -477,7 +477,7 @@ message ComponentState {
   // !!! note
   //    The list will contain unique members. No warning will exist twice in
   //    this list.
-  repeated ComponentErrorCode warnings = 3;
+  repeated ElectricalComponentErrorCode warnings = 3;
 
   // List of errors for the microgrid component.
   //
@@ -488,5 +488,5 @@ message ComponentState {
   // !!! note
   //    The list will contain unique members. No error will exist twice in
   //    this list.
-  repeated ComponentErrorCode errors = 4;
+  repeated ElectricalComponentErrorCode errors = 4;
 }

--- a/proto/frequenz/api/common/v1/microgrid/electrical_components/electrical_components.proto
+++ b/proto/frequenz/api/common/v1/microgrid/electrical_components/electrical_components.proto
@@ -13,11 +13,13 @@ package frequenz.api.common.v1.microgrid.electrical_components;
 import "frequenz/api/common/v1/metrics/bounds.proto";
 import "frequenz/api/common/v1/metrics/metric_sample.proto";
 import "frequenz/api/common/v1/microgrid/electrical_components/battery.proto";
-import "frequenz/api/common/v1/microgrid/electrical_components/ev_charger.proto";
+import
+  "frequenz/api/common/v1/microgrid/electrical_components/ev_charger.proto";
 import "frequenz/api/common/v1/microgrid/electrical_components/fuse.proto";
 import "frequenz/api/common/v1/microgrid/electrical_components/grid.proto";
 import "frequenz/api/common/v1/microgrid/electrical_components/inverter.proto";
-import "frequenz/api/common/v1/microgrid/electrical_components/transformer.proto";
+import
+  "frequenz/api/common/v1/microgrid/electrical_components/transformer.proto";
 import "frequenz/api/common/v1/microgrid/lifetime.proto";
 
 import "google/protobuf/timestamp.proto";
@@ -89,10 +91,13 @@ enum ElectricalComponentCategory {
 message ElectricalComponentCategoryMetadataVariant {
   oneof metadata {
     frequenz.api.common.v1.microgrid.electrical_components.Battery battery = 1;
-    frequenz.api.common.v1.microgrid.electrical_components.EvCharger ev_charger = 2;
+    frequenz.api.common.v1.microgrid.electrical_components.EvCharger
+      ev_charger = 2;
     frequenz.api.common.v1.microgrid.electrical_components.Fuse fuse = 3;
-    frequenz.api.common.v1.microgrid.electrical_components.GridConnectionPoint grid = 4;
-    frequenz.api.common.v1.microgrid.electrical_components.Inverter inverter = 5;
+    frequenz.api.common.v1.microgrid.electrical_components.GridConnectionPoint
+      grid = 4;
+    frequenz.api.common.v1.microgrid.electrical_components.Inverter
+      inverter = 5;
     frequenz.api.common.v1.microgrid.electrical_components.VoltageTransformer
       voltage_transformer = 6;
   }

--- a/proto/frequenz/api/common/v1/microgrid/electrical_components/electrical_components.proto
+++ b/proto/frequenz/api/common/v1/microgrid/electrical_components/electrical_components.proto
@@ -22,7 +22,7 @@ import "frequenz/api/common/v1/microgrid/lifetime.proto";
 
 import "google/protobuf/timestamp.proto";
 
-// Enumrated component categories.
+// Enumerated electrical component categories.
 enum ElectricalComponentCategory {
   // The component category is unspecified. This should not be used.
   ELECTRICAL_COMPONENT_CATEGORY_UNSPECIFIED = 0;

--- a/proto/frequenz/api/common/v1/microgrid/electrical_components/ev_charger.proto
+++ b/proto/frequenz/api/common/v1/microgrid/electrical_components/ev_charger.proto
@@ -8,7 +8,7 @@
 
 syntax = "proto3";
 
-package frequenz.api.common.v1.microgrid.components;
+package frequenz.api.common.v1.microgrid.electrical_components;
 
 // Enumerated EV charger types.
 enum EvChargerType {

--- a/proto/frequenz/api/common/v1/microgrid/electrical_components/fuse.proto
+++ b/proto/frequenz/api/common/v1/microgrid/electrical_components/fuse.proto
@@ -8,7 +8,7 @@
 
 syntax = "proto3";
 
-package frequenz.api.common.v1.microgrid.components;
+package frequenz.api.common.v1.microgrid.electrical_components;
 
 // A representation of a fuse.
 // The fuse component represents a fuse in the microgrid. It is used to protect

--- a/proto/frequenz/api/common/v1/microgrid/electrical_components/grid.proto
+++ b/proto/frequenz/api/common/v1/microgrid/electrical_components/grid.proto
@@ -8,7 +8,7 @@
 
 syntax = "proto3";
 
-package frequenz.api.common.v1.microgrid.components;
+package frequenz.api.common.v1.microgrid.electrical_components;
 
 // A representation of a grid connection point. This is the point where a
 // microgrid connects to the grid.

--- a/proto/frequenz/api/common/v1/microgrid/electrical_components/inverter.proto
+++ b/proto/frequenz/api/common/v1/microgrid/electrical_components/inverter.proto
@@ -8,7 +8,7 @@
 
 syntax = "proto3";
 
-package frequenz.api.common.v1.microgrid.components;
+package frequenz.api.common.v1.microgrid.electrical_components;
 
 // Enumerated inverter types.
 enum InverterType {

--- a/proto/frequenz/api/common/v1/microgrid/electrical_components/transformer.proto
+++ b/proto/frequenz/api/common/v1/microgrid/electrical_components/transformer.proto
@@ -8,7 +8,7 @@
 
 syntax = "proto3";
 
-package frequenz.api.common.v1.microgrid.components;
+package frequenz.api.common.v1.microgrid.electrical_components;
 
 // A representation of a voltage transformer.
 // Voltage transformers are used to step up or step down the voltage, keeping

--- a/pytests/test_common.py
+++ b/pytests/test_common.py
@@ -103,80 +103,88 @@ def test_module_import_microgrid_lifetime() -> None:
     assert lifetime_pb2_grpc is not None
 
 
-def test_module_import_microgrid_components() -> None:
+def test_module_import_microgrid_electrical_components() -> None:
     """Test that the modules can be imported."""
     # pylint: disable=import-outside-toplevel
-    from frequenz.api.common.v1.microgrid import components
+    from frequenz.api.common.v1.microgrid import electrical_components
 
-    assert components is not None
+    assert electrical_components is not None
 
     # pylint: disable=import-outside-toplevel
-    from frequenz.api.common.v1.microgrid.components import battery_pb2
+    from frequenz.api.common.v1.microgrid.electrical_components import battery_pb2
 
     assert battery_pb2 is not None
 
     # pylint: disable=import-outside-toplevel
-    from frequenz.api.common.v1.microgrid.components import battery_pb2_grpc
+    from frequenz.api.common.v1.microgrid.electrical_components import battery_pb2_grpc
 
     assert battery_pb2_grpc is not None
 
     # pylint: disable=import-outside-toplevel
-    from frequenz.api.common.v1.microgrid.components import components_pb2
+    from frequenz.api.common.v1.microgrid.electrical_components import (
+        electrical_components_pb2,
+    )
 
-    assert components_pb2 is not None
-
-    # pylint: disable=import-outside-toplevel
-    from frequenz.api.common.v1.microgrid.components import components_pb2_grpc
-
-    assert components_pb2_grpc is not None
+    assert electrical_components_pb2 is not None
 
     # pylint: disable=import-outside-toplevel
-    from frequenz.api.common.v1.microgrid.components import ev_charger_pb2
+    from frequenz.api.common.v1.microgrid.electrical_components import (
+        electrical_components_pb2_grpc,
+    )
+
+    assert electrical_components_pb2_grpc is not None
+
+    # pylint: disable=import-outside-toplevel
+    from frequenz.api.common.v1.microgrid.electrical_components import ev_charger_pb2
 
     assert ev_charger_pb2 is not None
 
     # pylint: disable=import-outside-toplevel
-    from frequenz.api.common.v1.microgrid.components import ev_charger_pb2_grpc
+    from frequenz.api.common.v1.microgrid.electrical_components import (
+        ev_charger_pb2_grpc,
+    )
 
     assert ev_charger_pb2_grpc is not None
 
     # pylint: disable=import-outside-toplevel
-    from frequenz.api.common.v1.microgrid.components import fuse_pb2
+    from frequenz.api.common.v1.microgrid.electrical_components import fuse_pb2
 
     assert fuse_pb2 is not None
 
     # pylint: disable=import-outside-toplevel
-    from frequenz.api.common.v1.microgrid.components import fuse_pb2_grpc
+    from frequenz.api.common.v1.microgrid.electrical_components import fuse_pb2_grpc
 
     assert fuse_pb2_grpc is not None
 
     # pylint: disable=import-outside-toplevel
-    from frequenz.api.common.v1.microgrid.components import grid_pb2
+    from frequenz.api.common.v1.microgrid.electrical_components import grid_pb2
 
     assert grid_pb2 is not None
 
     # pylint: disable=import-outside-toplevel
-    from frequenz.api.common.v1.microgrid.components import grid_pb2_grpc
+    from frequenz.api.common.v1.microgrid.electrical_components import grid_pb2_grpc
 
     assert grid_pb2_grpc is not None
 
     # pylint: disable=import-outside-toplevel
-    from frequenz.api.common.v1.microgrid.components import inverter_pb2
+    from frequenz.api.common.v1.microgrid.electrical_components import inverter_pb2
 
     assert inverter_pb2 is not None
 
     # pylint: disable=import-outside-toplevel
-    from frequenz.api.common.v1.microgrid.components import inverter_pb2_grpc
+    from frequenz.api.common.v1.microgrid.electrical_components import inverter_pb2_grpc
 
     assert inverter_pb2_grpc is not None
 
     # pylint: disable=import-outside-toplevel
-    from frequenz.api.common.v1.microgrid.components import transformer_pb2
+    from frequenz.api.common.v1.microgrid.electrical_components import transformer_pb2
 
     assert transformer_pb2 is not None
 
     # pylint: disable=import-outside-toplevel
-    from frequenz.api.common.v1.microgrid.components import transformer_pb2_grpc
+    from frequenz.api.common.v1.microgrid.electrical_components import (
+        transformer_pb2_grpc,
+    )
 
     assert transformer_pb2_grpc is not None
 


### PR DESCRIPTION
This change is in preparation for communication components to just the protobuf definition. The PR disambiguates electrical components by adding `Electrical` prefix to message/enum types, `electrical_` to module and path names, and `ELECTRICAL_` to enum fields.

I have not extensively updated the comments in the protobuf definitions a that would have created an unwieldy diff that obscures the substantive change. I can follow up on that afterwards.