### PR TITLE
Remove dependabot for submodules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -67,21 +67,3 @@ updates:
       artifacts:
         patterns:
           - "actions/*-artifact"
-
-  - package-ecosystem: "gitsubmodule"
-    directory: "/"
-    # We only want to track updates on google api common because the
-    # dependencies to other submodules are also indirectly tracked by the
-    # python dependencies (and because the gitsubmodule dependency tracker
-    # doesn't support updating only to tags or following semver, see
-    # https://github.com/dependabot/dependabot-core/issues/1639 for details)
-    # We do so by explicitly ignoring the other submodules, as `ignore` all
-    # + `allow` one doesn't seem to work.
-    ignore:
-      - dependency-name: "submodules/frequenz-api-common"
-    schedule:
-      interval: "weekly"
-      time: "06:00"
-    labels:
-      - "part:tooling"
-      - "type:tech-debt"


### PR DESCRIPTION
This repository doesn't use submodules anymore (in the past it had google common api as a submodule).
