### PR TITLE
Reorganize the contents of a few proto files

### DIFF
--- a/proto/frequenz/api/common/v1/microgrid/communication_components/communication_components.proto
+++ b/proto/frequenz/api/common/v1/microgrid/communication_components/communication_components.proto
@@ -76,92 +76,6 @@ enum CommunicationComponentDiagnosticCode {
   // Hardware fault due to overheating.
   COMMUNICATION_COMPONENT_DIAGNOSTIC_CODE_OVER_TEMPERATURE = 8;
 }
-
-// A single snapshot of a communication component's state, diagnostics, and timing.
-//
-// !!! note "snapshot semantics"
-//     all fields in this message represent the component's view at one point
-//     in time, so there is only a single `snapshot_time`. any parallel reads
-//     happening to produce this data are collapsed under that timestamp.
-message CommunicationComponentStateSnapshot {
-  // the utc time when this snapshot was taken.
-  google.protobuf.Timestamp snapshot_time = 1;
-
-  // one or more high-level state codes active at snapshot_time.
-  //
-  // !!! note
-  //     typical usage is a single state (e.g., online), but multiple may
-  //     apply (e.g., connecting + degraded) if that makes sense.
-  repeated CommunicationComponentStateCode states = 2;
-
-  // non-critical warnings detected for the component.
-  //
-  // !!! note
-  //     warnings may coexist with an online state, indicating potential
-  //     issues that do not prevent basic operation.
-  repeated CommunicationComponentDiagnostic warnings = 3;
-
-  // critical errors currently affecting the component.
-  //
-  // !!! note
-  //     an error state code should accompany entries here.
-  repeated CommunicationComponentDiagnostic errors = 4;
-}
-
-// Represents an error or warning condition reported by a microgrid
-// communication component.
-//
-// This message extends a standardized diagnostic code with optional
-// vendor-specific codes and contextual information for troubleshooting.
-//
-// !!! example "Typical Communication Component Warning"
-//     ```json
-//     {
-//       "diagnosticCode": "COMMUNICATION_COMPONENT_DIAGNOSTIC_CODE_CONFIGURATION_ERR",
-//       "vendorErrorCode": 1002,
-//       "message": "VLAN mismatch detected on port 3"
-//     }
-//     ```
-//
-// !!! note "Vendor-Specific Codes"
-//     When available, `vendor_error_code` reflects manufacturer-defined error
-//     identifiers.
-//     These codes are vendor- and firmware-specific and must be interpreted
-//     using the vendor's official documentation.
-message CommunicationComponentDiagnostic {
-  // A standardized diagnostic code representing the category of the issue.
-  CommunicationComponentDiagnosticCode diagnostic_code = 1;
-
-  // Optional vendor-provided error code for more granular diagnostics.
-  optional uint32 vendor_error_code = 2;
-
-  // Human-readable message providing additional context.
-  string message = 3;
-}
-
-// `CommunicationComponent` represents a communication component within a
-// microgrid.
-//
-// Communication components are networked devices responsible for enabling
-// communication between electrical components, sensors, controllers, and other
-// network devices.
-message CommunicationComponent {
-  // Unique identifier of the communication component.
-  uint64 id = 1;
-
-  // Unique identifier of the parent microgrid.
-  uint64 microgrid_id = 2;
-
-  // Human-readable name of the communication component.
-  string name = 3;
-
-  // Category identifying the type of the communication component.
-  CommunicationComponentCategory category = 4;
-
-  // List of IP addresses assigned to this communication component.
-  repeated string ip_addresses = 5;
-}
-
 // `CommunicationComponentCategory` enumerates possible types of communication
 // components within the microgrid.
 //
@@ -197,3 +111,89 @@ enum CommunicationComponentCategory {
   // between legacy equipment and modern network infrastructures.
   COMMUNICATION_COMPONENT_CATEGORY_SERIAL_GATEWAY = 6;
 }
+
+// `CommunicationComponent` represents a communication component within a
+// microgrid.
+//
+// Communication components are networked devices responsible for enabling
+// communication between electrical components, sensors, controllers, and other
+// network devices.
+message CommunicationComponent {
+  // Unique identifier of the communication component.
+  uint64 id = 1;
+
+  // Unique identifier of the parent microgrid.
+  uint64 microgrid_id = 2;
+
+  // Human-readable name of the communication component.
+  string name = 3;
+
+  // Category identifying the type of the communication component.
+  CommunicationComponentCategory category = 4;
+
+  // List of IP addresses assigned to this communication component.
+  repeated string ip_addresses = 5;
+}
+
+// Represents an error or warning condition reported by a microgrid
+// communication component.
+//
+// This message extends a standardized diagnostic code with optional
+// vendor-specific codes and contextual information for troubleshooting.
+//
+// !!! example "Typical Communication Component Warning"
+//     ```json
+//     {
+//       "diagnosticCode": "COMMUNICATION_COMPONENT_DIAGNOSTIC_CODE_CONFIGURATION_ERR",
+//       "vendorErrorCode": 1002,
+//       "message": "VLAN mismatch detected on port 3"
+//     }
+//     ```
+//
+// !!! note "Vendor-Specific Codes"
+//     When available, `vendor_error_code` reflects manufacturer-defined error
+//     identifiers.
+//     These codes are vendor- and firmware-specific and must be interpreted
+//     using the vendor's official documentation.
+message CommunicationComponentDiagnostic {
+  // A standardized diagnostic code representing the category of the issue.
+  CommunicationComponentDiagnosticCode diagnostic_code = 1;
+
+  // Optional vendor-provided error code for more granular diagnostics.
+  optional uint32 vendor_error_code = 2;
+
+  // Human-readable message providing additional context.
+  string message = 3;
+}
+
+// A single snapshot of a communication component's state, diagnostics, and timing.
+//
+// !!! note "snapshot semantics"
+//     all fields in this message represent the component's view at one point
+//     in time, so there is only a single `snapshot_time`. any parallel reads
+//     happening to produce this data are collapsed under that timestamp.
+message CommunicationComponentStateSnapshot {
+  // the utc time when this snapshot was taken.
+  google.protobuf.Timestamp snapshot_time = 1;
+
+  // one or more high-level state codes active at snapshot_time.
+  //
+  // !!! note
+  //     typical usage is a single state (e.g., online), but multiple may
+  //     apply (e.g., connecting + degraded) if that makes sense.
+  repeated CommunicationComponentStateCode states = 2;
+
+  // non-critical warnings detected for the component.
+  //
+  // !!! note
+  //     warnings may coexist with an online state, indicating potential
+  //     issues that do not prevent basic operation.
+  repeated CommunicationComponentDiagnostic warnings = 3;
+
+  // critical errors currently affecting the component.
+  //
+  // !!! note
+  //     an error state code should accompany entries here.
+  repeated CommunicationComponentDiagnostic errors = 4;
+}
+

--- a/proto/frequenz/api/common/v1/microgrid/communication_components/communication_components.proto
+++ b/proto/frequenz/api/common/v1/microgrid/communication_components/communication_components.proto
@@ -173,7 +173,7 @@ message CommunicationComponentDiagnostic {
 //     in time, so there is only a single `snapshot_time`. any parallel reads
 //     happening to produce this data are collapsed under that timestamp.
 message CommunicationComponentStateSnapshot {
-  // the utc time when this snapshot was taken.
+  // the UTC time when this snapshot was taken.
   google.protobuf.Timestamp snapshot_time = 1;
 
   // one or more high-level state codes active at snapshot_time.

--- a/proto/frequenz/api/common/v1/microgrid/electrical_components/electrical_components.proto
+++ b/proto/frequenz/api/common/v1/microgrid/electrical_components/electrical_components.proto
@@ -87,22 +87,6 @@ enum ElectricalComponentCategory {
   ELECTRICAL_COMPONENT_CATEGORY_HVAC = 15;
 }
 
-// Metadata specific to a microgrid component.
-message ElectricalComponentCategoryMetadataVariant {
-  oneof metadata {
-    frequenz.api.common.v1.microgrid.electrical_components.Battery battery = 1;
-    frequenz.api.common.v1.microgrid.electrical_components.EvCharger
-      ev_charger = 2;
-    frequenz.api.common.v1.microgrid.electrical_components.Fuse fuse = 3;
-    frequenz.api.common.v1.microgrid.electrical_components.GridConnectionPoint
-      grid = 4;
-    frequenz.api.common.v1.microgrid.electrical_components.Inverter
-      inverter = 5;
-    frequenz.api.common.v1.microgrid.electrical_components.VoltageTransformer
-      voltage_transformer = 6;
-  }
-}
-
 // ElectricalComponentStatus defines the possible statuses for a component.
 //
 // !!! note
@@ -119,144 +103,6 @@ enum ElectricalComponentStatus {
 
   // The component is inactive.
   ELECTRICAL_COMPONENT_STATUS_INACTIVE = 2;
-}
-
-// Microgrid electrical component details.
-message ElectricalComponent {
-  // The component ID.
-  uint64 id = 1;
-
-  // Unique identifier of the parent microgrid_id.
-  uint64 microgrid_id = 2;
-
-  // The component name.
-  string name = 3;
-
-  // The component category. E.g., Inverter, Battery, etc.
-  ElectricalComponentCategory category = 4;
-
-  // The metadata specific to the component category type.
-  ElectricalComponentCategoryMetadataVariant category_type = 5;
-
-  // The component manufacturer.
-  string manufacturer = 6;
-
-  // The model name of the component.
-  string model_name = 7;
-
-  // The status of the component.
-  ElectricalComponentStatus status = 8;
-
-  // The operational lifetime of the component.
-  frequenz.api.common.v1.microgrid.Lifetime operational_lifetime = 9;
-
-  // List of rated bounds present for the component identified by Metric.
-  repeated MetricConfigBounds metric_config_bounds = 10;
-}
-
-// MetricConfigBounds describes a set of limits for a specific metric consisting
-// of a lower and upper bound for said metric.
-//
-// This can be used for example to specify an allowed range of power output
-// for a component.
-message MetricConfigBounds {
-  // Metric type the config bounds are for
-  frequenz.api.common.v1.metrics.Metric metric = 1;
-
-  // The set of bounds for the specified metric.
-  //
-  // This contains the lower and upper bounds for said metric.
-  // Sources these may be derived from include the component configuration,
-  // manufacturers limits, and limits of other devices.
-  frequenz.api.common.v1.metrics.Bounds config_bounds = 2;
-}
-
-// ElectricalComponentConnection describes a single electrical link between two
-// components within a microgrid, effectively representing the physical wiring
-// as viewed from the grid connection point, if one exists, or from the
-// islanding point, in case of an islanded microgrids.
-//
-// !!! note "Physical Representation"
-//     This message is not about data flow but rather about the physical
-//     electrical connections between components. Therefore, the IDs for the
-//     source and destination components correspond to the actual setup within
-//     the microgrid.
-//
-// !!! note "Direction"
-//     The direction of the connection follows the flow of current away from the
-//     grid connection point, or in case of islands, away from the islanding
-//     point. This direction is aligned with positive current according to the
-//     [Passive Sign Convention]
-//     (https://en.wikipedia.org/wiki/Passive_sign_convention).
-//
-// !!! info "Historical Data"
-//     The timestamps of when a connection was created and terminated allows for
-//     tracking the changes over time to a microgrid, providing insights into
-//     when and how the microgrid infrastructure has been modified.
-//
-message ElectricalComponentConnection {
-  // Unique identifier of the component where the connection originates. This is
-  // aligned with the direction of current flow away from the grid connection
-  // point, or in case of islands, away from the islanding point.
-  uint64 source_component_id = 1;
-
-  // Unique ID of the component where the connection terminates. This is the
-  // component towards which the current flows.
-  uint64 destination_component_id = 2;
-
-  // The operational lifetime of the connection.
-  frequenz.api.common.v1.microgrid.Lifetime operational_lifetime = 3;
-}
-
-// ElectricalComponentData message aggregates multiple metrics, operational
-// states, and errors, related to a specific microgrid component.
-//
-// !!! example
-//   Example output of a component data message:
-//   ```
-//    {
-//      ELECTRICAL_component_id: 13,
-//      metric_samples: [
-//        /* list of metrics for multiple timestamps */
-//        {
-//          sampled_at: "2023-10-01T00:00:00Z",
-//          metric: "DC_VOLTAGE_V",
-//          value: {},
-//          bounds: {},
-//        },
-//        {
-//          sampled_at: "2023-10-01T00:00:00Z",
-//          metric: "DC_VOLTAGE_V",
-//          value: {},
-//          bounds: {},
-//        }
-//      ],
-//      states: [
-//        /* list of states for multiple timestamps */
-//        {
-//          sampled_at: "2023-10-01T00:00:00Z",
-//          states: [],
-//          warnings: [],
-//          errors: [],
-//        },
-//        {
-//          sampled_at: "2023-10-01T00:00:00Z",
-//          states: [],
-//          warnings: [],
-//          errors: [],
-//        },
-//      ]
-//    }
-//  ```
-message ElectricalComponentData {
-  // The ID of the microgrid component.
-  uint64 component_id = 1;
-
-  // List of measurements for a metric of the specific microgrid component.
-  repeated frequenz.api.common.v1.metrics.MetricSample metric_samples = 2;
-
-  // List of states of a specific microgrid component.
-  repeated ElectricalComponentState states = 3;
 }
 
 // Enum to represent the various states that a component can be in.
@@ -455,6 +301,109 @@ enum ElectricalComponentDiagnosticCode {
   ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_RELAY_CYCLE_LIMIT_REACHED = 60;
 }
 
+// MetricConfigBounds describes a set of limits for a specific metric consisting
+// of a lower and upper bound for said metric.
+//
+// This can be used for example to specify an allowed range of power output
+// for a component.
+message MetricConfigBounds {
+  // Metric type the config bounds are for
+  frequenz.api.common.v1.metrics.Metric metric = 1;
+
+  // The set of bounds for the specified metric.
+  //
+  // This contains the lower and upper bounds for said metric.
+  // Sources these may be derived from include the component configuration,
+  // manufacturers limits, and limits of other devices.
+  frequenz.api.common.v1.metrics.Bounds config_bounds = 2;
+}
+
+// Metadata specific to a microgrid component.
+message ElectricalComponentCategoryMetadataVariant {
+  oneof metadata {
+    frequenz.api.common.v1.microgrid.electrical_components.Battery battery = 1;
+    frequenz.api.common.v1.microgrid.electrical_components.EvCharger
+      ev_charger = 2;
+    frequenz.api.common.v1.microgrid.electrical_components.Fuse fuse = 3;
+    frequenz.api.common.v1.microgrid.electrical_components.GridConnectionPoint
+      grid = 4;
+    frequenz.api.common.v1.microgrid.electrical_components.Inverter
+      inverter = 5;
+    frequenz.api.common.v1.microgrid.electrical_components.VoltageTransformer
+      voltage_transformer = 6;
+  }
+}
+
+// Microgrid electrical component details.
+message ElectricalComponent {
+  // The component ID.
+  uint64 id = 1;
+
+  // Unique identifier of the parent microgrid_id.
+  uint64 microgrid_id = 2;
+
+  // The component name.
+  string name = 3;
+
+  // The component category. E.g., Inverter, Battery, etc.
+  ElectricalComponentCategory category = 4;
+
+  // The metadata specific to the component category type.
+  ElectricalComponentCategoryMetadataVariant category_type = 5;
+
+  // The component manufacturer.
+  string manufacturer = 6;
+
+  // The model name of the component.
+  string model_name = 7;
+
+  // The status of the component.
+  ElectricalComponentStatus status = 8;
+
+  // The operational lifetime of the component.
+  frequenz.api.common.v1.microgrid.Lifetime operational_lifetime = 9;
+
+  // List of rated bounds present for the component identified by Metric.
+  repeated MetricConfigBounds metric_config_bounds = 10;
+}
+
+// ElectricalComponentConnection describes a single electrical link between two
+// components within a microgrid, effectively representing the physical wiring
+// as viewed from the grid connection point, if one exists, or from the
+// islanding point, in case of an islanded microgrids.
+//
+// !!! note "Physical Representation"
+//     This message is not about data flow but rather about the physical
+//     electrical connections between components. Therefore, the IDs for the
+//     source and destination components correspond to the actual setup within
+//     the microgrid.
+//
+// !!! note "Direction"
+//     The direction of the connection follows the flow of current away from the
+//     grid connection point, or in case of islands, away from the islanding
+//     point. This direction is aligned with positive current according to the
+//     [Passive Sign Convention]
+//     (https://en.wikipedia.org/wiki/Passive_sign_convention).
+//
+// !!! info "Historical Data"
+//     The timestamps of when a connection was created and terminated allows for
+//     tracking the changes over time to a microgrid, providing insights into
+//     when and how the microgrid infrastructure has been modified.
+//
+message ElectricalComponentConnection {
+  // Unique identifier of the component where the connection originates. This is
+  // aligned with the direction of current flow away from the grid connection
+  // point, or in case of islands, away from the islanding point.
+  uint64 source_component_id = 1;
+
+  // Unique ID of the component where the connection terminates. This is the
+  // component towards which the current flows.
+  uint64 destination_component_id = 2;
+
+  // The operational lifetime of the connection.
+  frequenz.api.common.v1.microgrid.Lifetime operational_lifetime = 3;
+}
+
 // Represents an error or warning condition reported by a microgrid electrical
 // component.
 //
@@ -532,4 +481,55 @@ message ElectricalComponentState {
   //    This list is expected to have errors if and only if the electrical
   //    component is in an error state.
   repeated ElectricalComponentDiagnostic errors = 4;
+}
+
+// ElectricalComponentData message aggregates multiple metrics, operational
+// states, and errors, related to a specific microgrid component.
+//
+// !!! example
+//   Example output of a component data message:
+//   ```
+//    {
+//      ELECTRICAL_component_id: 13,
+//      metric_samples: [
+//        /* list of metrics for multiple timestamps */
+//        {
+//          sampled_at: "2023-10-01T00:00:00Z",
+//          metric: "DC_VOLTAGE_V",
+//          value: {},
+//          bounds: {},
+//        },
+//        {
+//          sampled_at: "2023-10-01T00:00:00Z",
+//          metric: "DC_VOLTAGE_V",
+//          value: {},
+//          bounds: {},
+//        }
+//      ],
+//      states: [
+//        /* list of states for multiple timestamps */
+//        {
+//          sampled_at: "2023-10-01T00:00:00Z",
+//          states: [],
+//          warnings: [],
+//          errors: [],
+//        },
+//        {
+//          sampled_at: "2023-10-01T00:00:00Z",
+//          states: [],
+//          warnings: [],
+//          errors: [],
+//        },
+//      ]
+//    }
+//  ```
+message ElectricalComponentData {
+  // The ID of the microgrid component.
+  uint64 component_id = 1;
+
+  // List of measurements for a metric of the specific microgrid component.
+  repeated frequenz.api.common.v1.metrics.MetricSample metric_samples = 2;
+
+  // List of states of a specific microgrid component.
+  repeated ElectricalComponentState states = 3;
 }

--- a/proto/frequenz/api/common/v1/microgrid/sensors/sensors.proto
+++ b/proto/frequenz/api/common/v1/microgrid/sensors/sensors.proto
@@ -225,7 +225,7 @@ message SensorMetricSample {
 // !!! example
 //   Example output of a component data message:
 //   ```
-//    {
+//   {
 //      sensor_id: 13,
 //      metric_samples: [
 //        /* list of metrics for multiple timestamps */
@@ -247,9 +247,8 @@ message SensorMetricSample {
 //          errors: [],
 //        },
 //      ]
-//
-//    }
-//  ```
+//   }
+//   ```
 message SensorData {
   // The ID of the microgrid sensors.
   uint64 sensor_id = 1;

--- a/proto/frequenz/api/common/v1/microgrid/sensors/sensors.proto
+++ b/proto/frequenz/api/common/v1/microgrid/sensors/sensors.proto
@@ -42,31 +42,6 @@ enum SensorCategory {
   SENSOR_CATEGORY_GENERAL = 7;
 }
 
-// A sensor that measures a physical metric in the microgrid's surrounding
-// environment.
-message Sensor {
-  // A unique identifier for the sensor.
-  uint64 id = 1;
-
-  // Unique identifier of the parent microgrid_id.
-  uint64 microgrid_id = 2;
-
-  // An optional name for the sensor.
-  string name = 3;
-
-  // The category of the sensor.
-  SensorCategory category = 4;
-
-  // The sensor manufacturer.
-  string manufacturer = 5;
-
-  // The model name of the sensor.
-  string model_name = 6;
-
-  // The operational lifetime of the sensor.
-  frequenz.api.common.v1.microgrid.Lifetime operational_lifetime = 7;
-}
-
 // Enumrated sensor metrics.
 enum SensorMetric {
   // Unspecified.
@@ -107,46 +82,57 @@ enum SensorMetric {
   SENSOR_METRIC_DEW_POINT = 8;
 }
 
-// SensorData message aggregates multiple metrics, operational states, and
-// errors, related to a specific microgrid sensor.
-//
-// !!! example
-//   Example output of a component data message:
-//   ```
-//    {
-//      sensor_id: 13,
-//      metric_samples: [
-//        /* list of metrics for multiple timestamps */
-//        {
-//          sampled_at: "2023-10-01T00:00:00Z",
-//          metric: "METRIC_SENSOR_TEMPERATURE",
-//          value: metric_value_variant: {simple_metric: {value: 23.5},
-//        },
-//        {
-//          sampled_at: "2023-10-01T00:00:00Z",
-//          metric: "METRIC_SENSOR_RELATIVE_HUMIDITY",
-//          value: metric_value_variant: {simple_metric: {value: 23.5},
-//        }
-//      ],
-//      states: [
-//        {
-//          sampled_at: "2023-10-01T00:00:00Z",
-//          states: [],
-//          errors: [],
-//        },
-//      ]
-//
-//    }
-//  ```
-message SensorData {
-  // The ID of the microgrid sensors.
-  uint64 sensor_id = 1;
+// Enum to represent the various states that a sensor can be in.
+// This enum is unified across all sensor categories for consistency.
+enum SensorStateCode {
+  // Default value when the sensor state is not explicitly set.
+  // This is the zero value of the enum.
+  SENSOR_STATE_CODE_UNSPECIFIED = 0;
 
-  // List of measurements for a metric of the specific microgrid sensor.
-  repeated SensorMetricSample metric_samples = 2;
+  // The sensor is up and running.
+  SENSOR_STATE_CODE_ON = 1;
 
-  // List of states of a specific microgrid sensor.
-  repeated SensorState states = 3;
+  // The sensor is in an error state.
+  SENSOR_STATE_CODE_ERROR = 2;
+}
+
+// A representation of all possible warnings and errors that can occur in
+// sensors.
+enum SensorDiagnosticCode {
+  // Default value. No specific error is specified.
+  SENSOR_DIAGNOSTIC_CODE_UNSPECIFIED = 0;
+
+  // The sensor is reporting an unknown or an undefined error, and the sender
+  // cannot parse the sensor error to any of the variants below.
+  SENSOR_DIAGNOSTIC_CODE_UNKNOWN = 1;
+
+  // Error indicating an internal error within the sensor.
+  SENSOR_DIAGNOSTIC_CODE_INTERNAL = 2;
+}
+
+// A sensor that measures a physical metric in the microgrid's surrounding
+// environment.
+message Sensor {
+  // A unique identifier for the sensor.
+  uint64 id = 1;
+
+  // Unique identifier of the parent microgrid_id.
+  uint64 microgrid_id = 2;
+
+  // An optional name for the sensor.
+  string name = 3;
+
+  // The category of the sensor.
+  SensorCategory category = 4;
+
+  // The sensor manufacturer.
+  string manufacturer = 5;
+
+  // The model name of the sensor.
+  string model_name = 6;
+
+  // The operational lifetime of the sensor.
+  frequenz.api.common.v1.microgrid.Lifetime operational_lifetime = 7;
 }
 
 // Represents an error or warning condition reported by a microgrid sensor.
@@ -221,34 +207,6 @@ message SensorState {
   repeated SensorDiagnostic errors = 4;
 }
 
-// Enum to represent the various states that a sensor can be in.
-// This enum is unified across all sensor categories for consistency.
-enum SensorStateCode {
-  // Default value when the sensor state is not explicitly set.
-  // This is the zero value of the enum.
-  SENSOR_STATE_CODE_UNSPECIFIED = 0;
-
-  // The sensor is up and running.
-  SENSOR_STATE_CODE_ON = 1;
-
-  // The sensor is in an error state.
-  SENSOR_STATE_CODE_ERROR = 2;
-}
-
-// A representation of all possible warnings and errors that can occur in
-// sensors.
-enum SensorDiagnosticCode {
-  // Default value. No specific error is specified.
-  SENSOR_DIAGNOSTIC_CODE_UNSPECIFIED = 0;
-
-  // The sensor is reporting an unknown or an undefined error, and the sender
-  // cannot parse the sensor error to any of the variants below.
-  SENSOR_DIAGNOSTIC_CODE_UNKNOWN = 1;
-
-  // Error indicating an internal error within the sensor.
-  SENSOR_DIAGNOSTIC_CODE_INTERNAL = 2;
-}
-
 // Representation of a sampled sensor metric along with its value.
 message SensorMetricSample {
   // The UTC timestamp of when the metric was sampled.
@@ -260,3 +218,46 @@ message SensorMetricSample {
   // The value of the sampled metric.
   frequenz.api.common.v1.metrics.MetricValueVariant value = 3;
 }
+
+// SensorData message aggregates multiple metrics, operational states, and
+// errors, related to a specific microgrid sensor.
+//
+// !!! example
+//   Example output of a component data message:
+//   ```
+//    {
+//      sensor_id: 13,
+//      metric_samples: [
+//        /* list of metrics for multiple timestamps */
+//        {
+//          sampled_at: "2023-10-01T00:00:00Z",
+//          metric: "METRIC_SENSOR_TEMPERATURE",
+//          value: metric_value_variant: {simple_metric: {value: 23.5},
+//        },
+//        {
+//          sampled_at: "2023-10-01T00:00:00Z",
+//          metric: "METRIC_SENSOR_RELATIVE_HUMIDITY",
+//          value: metric_value_variant: {simple_metric: {value: 23.5},
+//        }
+//      ],
+//      states: [
+//        {
+//          sampled_at: "2023-10-01T00:00:00Z",
+//          states: [],
+//          errors: [],
+//        },
+//      ]
+//
+//    }
+//  ```
+message SensorData {
+  // The ID of the microgrid sensors.
+  uint64 sensor_id = 1;
+
+  // List of measurements for a metric of the specific microgrid sensor.
+  repeated SensorMetricSample metric_samples = 2;
+
+  // List of states of a specific microgrid sensor.
+  repeated SensorState states = 3;
+}
+


### PR DESCRIPTION
This commit reorganizes the contents of the following proto files:
- `communication_components.proto`
- `electrical_components.proto`
- `sensors.proto`

The reorganization includes:
- Moving the enums to the top of the file for better visibility and organization.
- Sequencing the messages in an arbitrary logical order, ensuring that related messages are grouped together.

This PR does not change the protobuf messages themselves in any way.