### PR TITLE
Rename category type field in ElectricalComponent

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -29,6 +29,8 @@
 - Renamed electrical component category `COMPONENT_CATEGORY_GRID` to `ELECTRICAL_COMPONENT_CATEGORY_GRID_CONNECTION_POINT` to clarify its meaning. Note that the change in the enum change is a part of a larger refactoring of the electrical component category enum.
 - The oneof variant `ComponentCategoryMetadataVariant.metadata.grid` has been renamed to `ElectricalComponentCategorySpecificInfo.info.grid_connection_point` to better reflect its purpose.
 - A new inverter type `INVERTER_TYPE_WIND_TURBINE` has been added to the `InverterType` enum.
+- Renamed `ComponentCategoryMetadataVariant` to `ElectricalComponentCategorySpecificInfo`.
+- Renamed field `ElectricalComponent.category_type` to `ElectricalComponent.category_specific_info` to better reflect its purpose.
 
 ## Bug Fixes
 

--- a/proto/frequenz/api/common/v1/microgrid/electrical_components/electrical_components.proto
+++ b/proto/frequenz/api/common/v1/microgrid/electrical_components/electrical_components.proto
@@ -349,8 +349,8 @@ message MetricConfigBounds {
 }
 
 // Metadata specific to a microgrid component.
-message ElectricalComponentCategoryMetadataVariant {
-  oneof metadata {
+message ElectricalComponentCategorySpecificInfo {
+  oneof kind {
     frequenz.api.common.v1.microgrid.electrical_components.Battery battery = 1;
     frequenz.api.common.v1.microgrid.electrical_components.EvCharger
       ev_charger = 2;
@@ -379,7 +379,7 @@ message ElectricalComponent {
   ElectricalComponentCategory category = 4;
 
   // The metadata specific to the component category type.
-  ElectricalComponentCategoryMetadataVariant category_type = 5;
+  ElectricalComponentCategorySpecificInfo category_specific_info = 5;
 
   // The component manufacturer.
   string manufacturer = 6;


### PR DESCRIPTION
This commit renames the folowing:
- `ComponentCatgoryMetadataVariant` to `ElectricalComponentCategorySpecificInfo`
- `ElectricalComponent.category_type` to `ElectricalComponent.category_specific_info`

These renames make the entity names better reflect their purpose.