### PR TITLE
Rename grid to grid_connection_point in electrical_components.proto

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -26,6 +26,8 @@
 - Renumber variants in the `Metric` enum to remove unnecessary gaps.
 - Added a new enum `ElectricalComponentControlMode` to define control modes for electrical components.
 - Renamed `metric_sample.proto` to `metrics.proto` to better reflect its content.
+- Renamed electrical component category `COMPONENT_CATEGORY_GRID` to `ELECTRICAL_COMPONENT_CATEGORY_GRID_CONNECTION_POINT` to clarify its meaning. Note that the change in the enum change is a part of a larger refactoring of the electrical component category enum.
+- The oneof variant `ComponentCategoryMetadataVariant.metadata.grid` has been renamed to `ElectricalComponentCategorySpecificInfo.info.grid_connection_point` to better reflect its purpose.
 
 ## Bug Fixes
 

--- a/proto/frequenz/api/common/v1/microgrid/electrical_components/electrical_components.proto
+++ b/proto/frequenz/api/common/v1/microgrid/electrical_components/electrical_components.proto
@@ -30,7 +30,7 @@ enum ElectricalComponentCategory {
   ELECTRICAL_COMPONENT_CATEGORY_UNSPECIFIED = 0;
 
   // The point where the local microgrid is connected to the grid.
-  ELECTRICAL_COMPONENT_CATEGORY_GRID = 1;
+  ELECTRICAL_COMPONENT_CATEGORY_GRID_CONNECTION_POINT = 1;
 
   // A meter, for measuring electrical metrics, e.g., current, voltage, etc.
   ELECTRICAL_COMPONENT_CATEGORY_METER = 2;
@@ -356,7 +356,7 @@ message ElectricalComponentCategoryMetadataVariant {
       ev_charger = 2;
     frequenz.api.common.v1.microgrid.electrical_components.Fuse fuse = 3;
     frequenz.api.common.v1.microgrid.electrical_components.GridConnectionPoint
-      grid = 4;
+      grid_connection_point = 4;
     frequenz.api.common.v1.microgrid.electrical_components.Inverter
       inverter = 5;
     frequenz.api.common.v1.microgrid.electrical_components.VoltageTransformer


### PR DESCRIPTION
This commit renames the electrical component category `COMPONENT_CATEGORY_GRID` to
`ELECTRICAL_COMPONENT_CATEGORY_GRID_CONNECTION_POINT` in the proto file. (the name change of the enum is part of a larger refactoring of the electrical component category enum).

The oneof variant `ComponentCategoryMetadataVariant.metadata.grid` has also been renamed to
`ElectricalComponentCategorySpecificInfo.info.grid_connection_point` to better reflect its purpose.

closes #255 