### PR TITLE
Fix typo in field name in `CommunicationComponentDiagnostic`

### DIFF
--- a/proto/frequenz/api/common/v1/microgrid/communication_components/communication_components.proto
+++ b/proto/frequenz/api/common/v1/microgrid/communication_components/communication_components.proto
@@ -159,8 +159,8 @@ message CommunicationComponentDiagnostic {
   // A standardized diagnostic code representing the category of the issue.
   CommunicationComponentDiagnosticCode diagnostic_code = 1;
 
-  // Optional vendor-provided error code for more granular diagnostics.
-  optional uint32 vendor_error_code = 2;
+  // Optional vendor-provided code for more granular diagnostics.
+  optional uint32 vendor_diagnostic_code = 2;
 
   // Human-readable message providing additional context.
   string message = 3;


### PR DESCRIPTION
The field name `vendor_error_code` in the
`CommunicationComponentDiagnostic` message was incorrectly named, since it is not an error code but a more general diagnostic code. This commit renames the field to `vendor_diagnostic_code` to better reflect its purpose.

closes #330 