### PR TITLE
Renamed `sampled_at` timestamps to `origin_time`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -33,6 +33,7 @@
 - Renamed field `ElectricalComponent.category_type` to `ElectricalComponent.category_specific_info` to better reflect its purpose.
 - Renamed `ElectricalComponentState` to `ElectricalComponentStateSnapshot` to better reflect its purpose.
 - Renamed `SensorState` to `SensorStateSnapshot` to better reflect its purpose.
+- Renamed `sampled_at` timestamps for state snapshots to `origin_time`.
 
 ## Bug Fixes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -34,6 +34,7 @@
 - Renamed `ElectricalComponentState` to `ElectricalComponentStateSnapshot` to better reflect its purpose.
 - Renamed `SensorState` to `SensorStateSnapshot` to better reflect its purpose.
 - Renamed `sampled_at` timestamps for state snapshots to `origin_time`.
+- Renamed `sampled_at` timestamps for metric samples to `sample_time`.
 
 ## Bug Fixes
 

--- a/proto/frequenz/api/common/v1/metrics/metrics.proto
+++ b/proto/frequenz/api/common/v1/metrics/metrics.proto
@@ -186,7 +186,7 @@ enum Metric {
 //     command, clients need to request current values within the bounds.
 message MetricSample {
   // The UTC timestamp of when the metric was sampled.
-  google.protobuf.Timestamp sampled_at = 1;
+  google.protobuf.Timestamp sample_time = 1;
 
   // The metric that was sampled.
   Metric metric = 2;

--- a/proto/frequenz/api/common/v1/microgrid/communication_components/communication_components.proto
+++ b/proto/frequenz/api/common/v1/microgrid/communication_components/communication_components.proto
@@ -173,7 +173,7 @@ message CommunicationComponentDiagnostic {
 //     in time, so there is only a single `snapshot_time`. any parallel reads
 //     happening to produce this data are collapsed under that timestamp.
 message CommunicationComponentStateSnapshot {
-  // the UTC time when this snapshot was taken.
+  // The UTC time when the state was originally captured.
   google.protobuf.Timestamp snapshot_time = 1;
 
   // one or more high-level state codes active at snapshot_time.

--- a/proto/frequenz/api/common/v1/microgrid/communication_components/communication_components.proto
+++ b/proto/frequenz/api/common/v1/microgrid/communication_components/communication_components.proto
@@ -174,7 +174,7 @@ message CommunicationComponentDiagnostic {
 //     happening to produce this data are collapsed under that timestamp.
 message CommunicationComponentStateSnapshot {
   // The UTC time when the state was originally captured.
-  google.protobuf.Timestamp snapshot_time = 1;
+  google.protobuf.Timestamp origin_time = 1;
 
   // one or more high-level state codes active at snapshot_time.
   //

--- a/proto/frequenz/api/common/v1/microgrid/electrical_components/electrical_components.proto
+++ b/proto/frequenz/api/common/v1/microgrid/electrical_components/electrical_components.proto
@@ -475,7 +475,7 @@ message ElectricalComponentDiagnostic {
 
 // Representation of a component state, warnings, and errors.
 message ElectricalComponentStateSnapshot {
-  // The time at which the state was sampled.
+  // The UTC time when the state was originally captured.
   google.protobuf.Timestamp origin_time = 1;
 
 

--- a/proto/frequenz/api/common/v1/microgrid/electrical_components/electrical_components.proto
+++ b/proto/frequenz/api/common/v1/microgrid/electrical_components/electrical_components.proto
@@ -524,13 +524,13 @@ message ElectricalComponentStateSnapshot {
 //      metric_samples: [
 //        /* list of metrics for multiple timestamps */
 //        {
-//          sampled_at: "2023-10-01T00:00:00Z",
+//          sample_time: "2023-10-01T00:00:00Z",
 //          metric: "DC_VOLTAGE_V",
 //          value: {},
 //          bounds: {},
 //        },
 //        {
-//          sampled_at: "2023-10-01T00:00:00Z",
+//          sample_time: "2023-10-01T00:00:00Z",
 //          metric: "DC_VOLTAGE_V",
 //          value: {},
 //          bounds: {},
@@ -539,13 +539,13 @@ message ElectricalComponentStateSnapshot {
 //      states: [
 //        /* list of states for multiple timestamps */
 //        {
-//          sampled_at: "2023-10-01T00:00:00Z",
+//          sample_time: "2023-10-01T00:00:00Z",
 //          states: [],
 //          warnings: [],
 //          errors: [],
 //        },
 //        {
-//          sampled_at: "2023-10-01T00:00:00Z",
+//          sample_time: "2023-10-01T00:00:00Z",
 //          states: [],
 //          warnings: [],
 //          errors: [],

--- a/proto/frequenz/api/common/v1/microgrid/electrical_components/electrical_components.proto
+++ b/proto/frequenz/api/common/v1/microgrid/electrical_components/electrical_components.proto
@@ -476,7 +476,7 @@ message ElectricalComponentDiagnostic {
 // Representation of a component state, warnings, and errors.
 message ElectricalComponentStateSnapshot {
   // The time at which the state was sampled.
-  google.protobuf.Timestamp sampled_at = 1;
+  google.protobuf.Timestamp origin_time = 1;
 
 
   // List of operational states currently active for the component.

--- a/proto/frequenz/api/common/v1/microgrid/sensors/sensors.proto
+++ b/proto/frequenz/api/common/v1/microgrid/sensors/sensors.proto
@@ -170,7 +170,7 @@ message SensorDiagnostic {
 // Representation of a sensor state and errors.
 message SensorStateSnapshot {
   // The time at which the state was sampled.
-  google.protobuf.Timestamp sampled_at = 1;
+  google.protobuf.Timestamp origin_time = 1;
 
   // List of states of the microgrid sensor.
   //

--- a/proto/frequenz/api/common/v1/microgrid/sensors/sensors.proto
+++ b/proto/frequenz/api/common/v1/microgrid/sensors/sensors.proto
@@ -169,7 +169,7 @@ message SensorDiagnostic {
 
 // Representation of a sensor state and errors.
 message SensorStateSnapshot {
-  // The time at which the state was sampled.
+  // The UTC time when the state was originally captured.
   google.protobuf.Timestamp origin_time = 1;
 
   // List of states of the microgrid sensor.

--- a/proto/frequenz/api/common/v1/microgrid/sensors/sensors.proto
+++ b/proto/frequenz/api/common/v1/microgrid/sensors/sensors.proto
@@ -210,7 +210,7 @@ message SensorStateSnapshot {
 // Representation of a sampled sensor metric along with its value.
 message SensorMetricSample {
   // The UTC timestamp of when the metric was sampled.
-  google.protobuf.Timestamp sampled_at = 1;
+  google.protobuf.Timestamp sample_time = 1;
 
   // The metric that was sampled.
   frequenz.api.common.v1.metrics.Metric metric = 2;
@@ -230,19 +230,19 @@ message SensorMetricSample {
 //      metric_samples: [
 //        /* list of metrics for multiple timestamps */
 //        {
-//          sampled_at: "2023-10-01T00:00:00Z",
+//          sample_time: "2023-10-01T00:00:00Z",
 //          metric: "METRIC_SENSOR_TEMPERATURE",
 //          value: metric_value_variant: {simple_metric: {value: 23.5},
 //        },
 //        {
-//          sampled_at: "2023-10-01T00:00:00Z",
+//          sample_time: "2023-10-01T00:00:00Z",
 //          metric: "METRIC_SENSOR_RELATIVE_HUMIDITY",
 //          value: metric_value_variant: {simple_metric: {value: 23.5},
 //        }
 //      ],
 //      states: [
 //        {
-//          sampled_at: "2023-10-01T00:00:00Z",
+//          sample_time: "2023-10-01T00:00:00Z",
 //          states: [],
 //          errors: [],
 //        },


### PR DESCRIPTION
closes #326 