### PR TITLE
Remove `SensorMetricSample` in favour of `MetricSample`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -35,6 +35,7 @@
 - Renamed `SensorState` to `SensorStateSnapshot` to better reflect its purpose.
 - Renamed `sampled_at` timestamps for state snapshots to `origin_time`.
 - Renamed `sampled_at` timestamps for metric samples to `sample_time`.
+- Remove `SensorMetricSample` in favour of using `MetricSample` for sensors.
 
 ## Bug Fixes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -36,6 +36,7 @@
 - Renamed `sampled_at` timestamps for state snapshots to `origin_time`.
 - Renamed `sampled_at` timestamps for metric samples to `sample_time`.
 - Remove `SensorMetricSample` in favour of using `MetricSample` for sensors.
+- Remove `SensorMetric` enum, since it was unused and redundant.
 
 ## Bug Fixes
 

--- a/proto/frequenz/api/common/v1/microgrid/sensors/sensors.proto
+++ b/proto/frequenz/api/common/v1/microgrid/sensors/sensors.proto
@@ -42,46 +42,6 @@ enum SensorCategory {
   SENSOR_CATEGORY_GENERAL = 7;
 }
 
-// Enumrated sensor metrics.
-enum SensorMetric {
-  // Unspecified.
-  SENSOR_METRIC_UNSPECIFIED = 0;
-
-  // Temperature.
-  // In Celsius (°C).
-  SENSOR_METRIC_TEMPERATURE = 1;
-
-  // Humidity
-  // In percentage (%).
-  SENSOR_METRIC_HUMIDITY = 2;
-
-  // Pressure
-  // In Pascal (Pa).
-  SENSOR_METRIC_PRESSURE = 3;
-
-  // Irradiance / Radiation flux
-  // In watts per square meter (W / m^2).
-  SENSOR_METRIC_IRRADIANCE = 4;
-
-  // Velocity
-  // In meters per second (m / s).
-  SENSOR_METRIC_VELOCITY = 5;
-
-  // Acceleration.
-  // In meters per second per second (m / s^2)
-  SENSOR_METRIC_ACCELERATION = 6;
-
-  // Metric to represent angles, for metrics like direction.
-  // In angles with respect to the (magnetic) North (°).
-  SENSOR_METRIC_ANGLE = 7;
-
-  // Dew point.
-  // The temperature at which the air becomes saturated with water vapor.
-  //
-  // In Celsius (°C).
-  SENSOR_METRIC_DEW_POINT = 8;
-}
-
 // Enum to represent the various states that a sensor can be in.
 // This enum is unified across all sensor categories for consistency.
 enum SensorStateCode {
@@ -205,18 +165,6 @@ message SensorStateSnapshot {
   //    This list is expected to have errors if and only if the sensor is in
   //    an error state.
   repeated SensorDiagnostic errors = 4;
-}
-
-// Representation of a sampled sensor metric along with its value.
-message SensorMetricSample {
-  // The UTC timestamp of when the metric was sampled.
-  google.protobuf.Timestamp sample_time = 1;
-
-  // The metric that was sampled.
-  frequenz.api.common.v1.metrics.Metric metric = 2;
-
-  // The value of the sampled metric.
-  frequenz.api.common.v1.metrics.MetricValueVariant value = 3;
 }
 
 // SensorData message aggregates multiple metrics, operational states, and

--- a/proto/frequenz/api/common/v1/microgrid/sensors/sensors.proto
+++ b/proto/frequenz/api/common/v1/microgrid/sensors/sensors.proto
@@ -233,11 +233,15 @@ message SensorMetricSample {
 //          sample_time: "2023-10-01T00:00:00Z",
 //          metric: "METRIC_SENSOR_TEMPERATURE",
 //          value: metric_value_variant: {simple_metric: {value: 23.5},
+//          bounds: {}
+//          source: {}
 //        },
 //        {
 //          sample_time: "2023-10-01T00:00:00Z",
 //          metric: "METRIC_SENSOR_RELATIVE_HUMIDITY",
 //          value: metric_value_variant: {simple_metric: {value: 23.5},
+//          bounds: {}
+//          source: "humidity_sensor_1"
 //        }
 //      ],
 //      states: [
@@ -254,7 +258,7 @@ message SensorData {
   uint64 sensor_id = 1;
 
   // List of measurements for a metric of the specific microgrid sensor.
-  repeated SensorMetricSample metric_samples = 2;
+  repeated frequenz.api.common.v1.metrics.MetricSample metric_samples = 2;
 
   // List of states of a specific microgrid sensor.
   repeated SensorStateSnapshot states = 3;


### PR DESCRIPTION
This commit removes the `SensorMetricSample` message in favour of using `MetricSample` for sensors. The `SensorMetricSample` message was a subset of the `MetricSample` message.

From a design perspective focused on consistency, flexibility, and minimizing API surface area while handling variations via optional fields (which is idiomatic in Protobuf3), there's a strong argument that `SensorMetricSample` is redundant and potentially confusing, and that having only `MetricSample` is a cleaner design.

closes #339