### PR TITLE
Rename `SensorStateCode` variant `ON` to `OK` in sensors.proto

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -38,6 +38,7 @@
 - Remove `SensorMetricSample` in favour of using `MetricSample` for sensors.
 - Remove `SensorMetric` enum, since it was unused and redundant.
 - Renamed `MetricSample.source` to `MetricSample.connection` to make it more specific as to what it refers to.
+- Rename `SensorStateCode.SENSOR_STATE_CODE_ON` to `SensorStateCode.SENSOR_STATE_CODE_OK`, to better indicate that we do not control on/off state of sensors.
 
 ## Bug Fixes
 

--- a/proto/frequenz/api/common/v1/microgrid/sensors/sensors.proto
+++ b/proto/frequenz/api/common/v1/microgrid/sensors/sensors.proto
@@ -50,7 +50,7 @@ enum SensorStateCode {
   SENSOR_STATE_CODE_UNSPECIFIED = 0;
 
   // The sensor is up and running.
-  SENSOR_STATE_CODE_ON = 1;
+  SENSOR_STATE_CODE_OK = 1;
 
   // The sensor is in an error state.
   SENSOR_STATE_CODE_ERROR = 2;


### PR DESCRIPTION
Sensor state `ON` is misleading, as it can mislead users to think that the API controls the on/off state of the sensor. This is not the case, as the API only provides information about the sensor's state. The sensor's state can be `OK` (indicating that the sensor is functioning correctly) or `ERROR` (indicating that the sensor is in an error state).

This change renames the `SENSOR_STATE_CODE_ON` variant to `SENSOR_STATE_CODE_OK`, which is more accurate and descriptive.