### PR TITLE
Rename `*Data` messages to `*Telemetry`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -39,6 +39,7 @@
 - Remove `SensorMetric` enum, since it was unused and redundant.
 - Renamed `MetricSample.source` to `MetricSample.connection` to make it more specific as to what it refers to.
 - Rename `SensorStateCode.SENSOR_STATE_CODE_ON` to `SensorStateCode.SENSOR_STATE_CODE_OK`, to better indicate that we do not control on/off state of sensors.
+- Rename `ComponentData` to `ElectricalComponentTelemetry` to better specify its purpose of encapsulating general telemetry data from electrical components.
 
 ## Bug Fixes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -40,6 +40,7 @@
 - Renamed `MetricSample.source` to `MetricSample.connection` to make it more specific as to what it refers to.
 - Rename `SensorStateCode.SENSOR_STATE_CODE_ON` to `SensorStateCode.SENSOR_STATE_CODE_OK`, to better indicate that we do not control on/off state of sensors.
 - Rename `ComponentData` to `ElectricalComponentTelemetry` to better specify its purpose of encapsulating general telemetry data from electrical components.
+- Rename `SensorData` to `SensorTelemetry` to better specify its purpose of encapsulating general telemetry data from sensors.
 
 ## Bug Fixes
 

--- a/proto/frequenz/api/common/v1/microgrid/electrical_components/electrical_components.proto
+++ b/proto/frequenz/api/common/v1/microgrid/electrical_components/electrical_components.proto
@@ -513,7 +513,7 @@ message ElectricalComponentStateSnapshot {
   repeated ElectricalComponentDiagnostic errors = 4;
 }
 
-// ElectricalComponentData message aggregates multiple metrics, operational
+// ElectricalComponentTelemetry message aggregates multiple metrics, operational
 // states, and errors, related to a specific microgrid component.
 //
 // !!! example
@@ -555,7 +555,7 @@ message ElectricalComponentStateSnapshot {
 //      ]
 //    }
 //  ```
-message ElectricalComponentData {
+message ElectricalComponentTelemetry {
   // The ID of the microgrid component.
   uint64 component_id = 1;
 

--- a/proto/frequenz/api/common/v1/microgrid/sensors/sensors.proto
+++ b/proto/frequenz/api/common/v1/microgrid/sensors/sensors.proto
@@ -167,7 +167,7 @@ message SensorStateSnapshot {
   repeated SensorDiagnostic errors = 4;
 }
 
-// SensorData message aggregates multiple metrics, operational states, and
+// SensorTelemetry message aggregates multiple metrics, operational states, and
 // errors, related to a specific microgrid sensor.
 //
 // !!! example
@@ -201,7 +201,7 @@ message SensorStateSnapshot {
 //      ]
 //   }
 //   ```
-message SensorData {
+message SensorTelemetry {
   // The ID of the microgrid sensors.
   uint64 sensor_id = 1;
 


### PR DESCRIPTION
These messages holds two different types of data: metric samples and state snapshots, which when combined into a single message, represent the telemetry data of a component/sensor. The name change reflects this purpose more accurately.