### PR TITLE
Add new codes to `ElectricalComponentDiagnosticCode` enum

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -43,6 +43,8 @@
 - Rename `SensorData` to `SensorTelemetry` to better specify its purpose of encapsulating general telemetry data from sensors.
 - The following changes have been made to the `ElectricalComponentDiagnosticCode` enum (previously `ComponentErrorCode`):
     - The code `UNDERVOLTAGE_SHUTDOWN` has been removed in favour of `UNDERVOLTAGE`.
+    - New diagnostic codes have been added to cover more cases, especially for inverters.
+    - The codes have been renumbered.
 
 ## Bug Fixes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -41,6 +41,8 @@
 - Rename `SensorStateCode.SENSOR_STATE_CODE_ON` to `SensorStateCode.SENSOR_STATE_CODE_OK`, to better indicate that we do not control on/off state of sensors.
 - Rename `ComponentData` to `ElectricalComponentTelemetry` to better specify its purpose of encapsulating general telemetry data from electrical components.
 - Rename `SensorData` to `SensorTelemetry` to better specify its purpose of encapsulating general telemetry data from sensors.
+- The following changes have been made to the `ElectricalComponentDiagnosticCode` enum (previously `ComponentErrorCode`):
+    - The code `UNDERVOLTAGE_SHUTDOWN` has been removed in favour of `UNDERVOLTAGE`.
 
 ## Bug Fixes
 

--- a/proto/frequenz/api/common/v1/microgrid/electrical_components/electrical_components.proto
+++ b/proto/frequenz/api/common/v1/microgrid/electrical_components/electrical_components.proto
@@ -264,50 +264,47 @@ enum ElectricalComponentDiagnosticCode {
   // sanity checks to fail.
   ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_PLAUSIBILITY_ERROR = 13;
 
-  // There is or was a system shutdown due to undervoltage.
-  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_UNDERVOLTAGE_SHUTDOWN = 14;
-
-  // There is an unexpected pilot failure in an electric vehicle (EV) component.
-  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_EV_UNEXPECTED_PILOT_FAILURE = 15;
-
   // A fault current has been detected in the component.
-  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_FAULT_CURRENT = 16;
+  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_FAULT_CURRENT = 14;
 
   // A short circuit has been detected in the component.
-  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_SHORT_CIRCUIT = 17;
+  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_SHORT_CIRCUIT = 15;
 
   // The component has been configured incorrectly.
-  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_CONFIG_ERROR = 18;
+  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_CONFIG_ERROR = 16;
 
   // A illegal state has been requested for the component.
   ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_ILLEGAL_COMPONENT_STATE_CODE_REQUESTED
-    = 19;
+    = 17;
 
   // The hardware of the component is inaccessible.
-  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_HARDWARE_INACCESSIBLE = 20;
+  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_HARDWARE_INACCESSIBLE = 18;
 
   // There is an internal error within the component.
-  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_INTERNAL = 21;
+  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_INTERNAL = 19;
 
   // The component is unauthorized to perform the last requested action.
-  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_UNAUTHORIZED = 22;
+  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_UNAUTHORIZED = 20;
+
+  // There is an unexpected pilot failure in an electric vehicle (EV) component.
+  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_EV_UNEXPECTED_PILOT_FAILURE = 40;
 
   // The electric vehicle (EV) cable was abruptly unplugged from the charging
   // station.
   ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_EV_CHARGING_CABLE_UNPLUGGED_FROM_STATION
-    = 40;
+    = 41;
 
   // The electric vehicle (EV) cable was abruptly unplugged from the vehicle.
-  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_EV_CHARGING_CABLE_UNPLUGGED_FROM_EV = 41;
+  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_EV_CHARGING_CABLE_UNPLUGGED_FROM_EV = 42;
 
   // There is a cable lock failure with the electric vehicle (EV).
-  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_EV_CHARGING_CABLE_LOCK_FAILED = 42;
+  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_EV_CHARGING_CABLE_LOCK_FAILED = 43;
 
   // The electric vehicle (EV) charging cable is invalid.
-  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_EV_CHARGING_CABLE_INVALID = 43;
+  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_EV_CHARGING_CABLE_INVALID = 44;
 
   // The incompatible electric vehicle (EV) charging plug is invalid.
-  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_EV_CONSUMER_INCOMPATIBLE = 44;
+  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_EV_CONSUMER_INCOMPATIBLE = 45;
 
   // There is a battery system imbalance.
   ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_BATTERY_IMBALANCE = 50;

--- a/proto/frequenz/api/common/v1/microgrid/electrical_components/electrical_components.proto
+++ b/proto/frequenz/api/common/v1/microgrid/electrical_components/electrical_components.proto
@@ -286,6 +286,56 @@ enum ElectricalComponentDiagnosticCode {
   // The component is unauthorized to perform the last requested action.
   ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_UNAUTHORIZED = 20;
 
+  // There is excessive leakage current in the component.
+  // The threshold for excessive leakage current is defined by the component
+  // manufacturer.
+  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_EXCESS_LEAKAGE_CURRENT = 21;
+
+  // The component is inoperable due to the insulation resistance being too low.
+  // The threshold for low insulation resistance is defined by the component
+  // manufacturer, or can be configured by the user in the component.
+  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_LOW_SYSTEM_INSULATION_RESISTANCE = 22;
+
+  // The component is inoperable due to the faulty grounding.
+  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_GROUND_FAULT = 23;
+
+  // The component is inoperable due to arcing.
+  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_ARC_FAULT = 24;
+
+  // The component is inoperable due to its fan being faulty.
+  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_FAN_FAULT = 25;
+
+  // The component is inoperable due to the component's hardware being faulty.
+  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_HARDWARE_FAULT = 26;
+
+  // the component is inoperable due to it hardware being faulty.
+  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_PROTECTIVE_SHUTDOWN = 27;
+
+  // The component is inoperable due to the grid voltage being too high.
+  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_GRID_OVERVOLTAGE = 30;
+
+  // The component is inoperable due to the grid voltage being too low.
+  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_GRID_UNDERVOLTAGE = 31;
+
+  // The component is inoperable due to the grid frequency being too high.
+  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_GRID_OVERFREQUENCY = 32;
+
+  // The component is inoperable due to the grid frequency being too low.
+  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_GRID_UNDERFREQUENCY = 33;
+
+  // The component is inoperable due to the grid being disconnected, despite
+  // the AC relay being closed.
+  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_GRID_DISCONNECTED = 34;
+
+  // The component is inoperable due to the grid voltage being imbalanced.
+  // This happens when the voltage of one or more phases is outside the
+  // acceptable range.
+  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_GRID_VOLTAGE_IMBALANCE = 35;
+
+  // The component is inoperable due to the grid being in a non-standard
+  // configuration.
+  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_GRID_ABNORMAL = 36;
+
   // There is an unexpected pilot failure in an electric vehicle (EV) component.
   ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_EV_UNEXPECTED_PILOT_FAILURE = 40;
 
@@ -326,6 +376,28 @@ enum ElectricalComponentDiagnosticCode {
 
   // The battery's DC contactor or relays have reached end of life.
   ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_RELAY_CYCLE_LIMIT_REACHED = 60;
+
+  // The PV panels have been connected with reversed polarity.
+  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_PV_REVERSAL_POLARITY = 70;
+
+  // The PV panels are underperforming.
+  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_PV_UNDERPERFORMANCE = 71;
+
+  // The PV panels have a fault.
+  // The component is not able to determine or specify the fault.
+  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_PV_FAULT = 72;
+
+  // The PV panels are receiving a reverse current.
+  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_PV_REVERSE_CURRENT = 73;
+
+  // The PV panels are not grounded properly.
+  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_PV_GROUND_FAULT = 74;
+
+  // The inverter is inoperable due to the DC voltage being too low.
+  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_INVERTER_DC_UNDERVOLTAGE = 80;
+
+  // The inverter is inoperable due to the DC voltage being too high.
+  ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_INVERTER_DC_OVERVOLTAGE = 81;
 }
 
 // MetricConfigBounds describes a set of limits for a specific metric consisting

--- a/proto/frequenz/api/common/v1/microgrid/electrical_components/electrical_components.proto
+++ b/proto/frequenz/api/common/v1/microgrid/electrical_components/electrical_components.proto
@@ -308,7 +308,7 @@ enum ElectricalComponentDiagnosticCode {
   // The component is inoperable due to the component's hardware being faulty.
   ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_HARDWARE_FAULT = 26;
 
-  // the component is inoperable due to it hardware being faulty.
+  // The component is inoperable due to its hardware being faulty.
   ELECTRICAL_COMPONENT_DIAGNOSTIC_CODE_PROTECTIVE_SHUTDOWN = 27;
 
   // The component is inoperable due to the grid voltage being too high.


### PR DESCRIPTION
The following changes have been made to the `ElectricalComponentDiagnosticCode` enum (previously `ComponentErrorCode`):
- The code `UNDERVOLTAGE_SHUTDOWN` has been removed in favour of `UNDERVOLTAGE`.
- New diagnostic codes have been added to cover more cases, especially for inverters.
- The codes have been renumbered.

closes #231 