### PR TITLE
Avoid warnings about protobuf gencode version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,7 +140,15 @@ disable = [
 
 [tool.pytest.ini_options]
 testpaths = ["pytests"]
-addopts = "-W=all -Werror -Wdefault::DeprecationWarning -Wdefault::PendingDeprecationWarning -vv"
+addopts = "-vv"
+filterwarnings = [
+  "error",
+  "once::DeprecationWarning",
+  "once::PendingDeprecationWarning",
+  # We use a raw string (single quote) to avoid the need to escape special
+  # chars as this is a regex
+  'ignore:Protobuf gencode version .*exactly one major version older.*:UserWarning',
+]
 
 [tool.mypy]
 explicit_package_bases = true


### PR DESCRIPTION
We know about this warning and it is not a problem for us, as protobuf gurantees compatibility between two consecutive major versions.

When we really need to bump the dependency, we'll get an error that is not ignored.
