### PR TITLE
Move `location.proto` to `types/location.proto`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -65,6 +65,8 @@
 
 - The minimum allowed version of `protobuf` and `grpcio` has been updated to 6.31.1 and 1.72.1 respectively, you might also need to bump your dependencies accordingly.
 
+- The file `location.proto` has been moved to the `types` package, moving the message `Location` to `types.Location`.
+
 ## New Features
 
 Added many new messages and enum values:

--- a/proto/frequenz/api/common/v1/microgrid/microgrid.proto
+++ b/proto/frequenz/api/common/v1/microgrid/microgrid.proto
@@ -10,7 +10,7 @@ syntax = "proto3";
 package frequenz.api.common.v1.microgrid;
 
 import "frequenz/api/common/v1/grid/delivery_area.proto";
-import "frequenz/api/common/v1/location.proto";
+import "frequenz/api/common/v1/types/location.proto";
 
 import "google/protobuf/timestamp.proto";
 
@@ -60,7 +60,7 @@ message Microgrid {
   // Physical location of the microgrid, in geographical co-ordinates.
   //
   // If the location is not known, this field will be missing.
-  frequenz.api.common.v1.Location location = 5;
+  frequenz.api.common.v1.types.Location location = 5;
 
   // The current status of the microgrid.
   MicrogridStatus status = 6;

--- a/proto/frequenz/api/common/v1/types/location.proto
+++ b/proto/frequenz/api/common/v1/types/location.proto
@@ -7,7 +7,7 @@
 
 syntax = "proto3";
 
-package frequenz.api.common.v1;
+package frequenz.api.common.v1.types;
 
 // A pair of geographical co-ordinates, representing the location of a place.
 message Location {

--- a/pytests/test_common.py
+++ b/pytests/test_common.py
@@ -212,12 +212,12 @@ def test_module_import_microgrid_communication_components() -> None:
 def test_module_import_location() -> None:
     """Test that the modules can be imported."""
     # pylint: disable=import-outside-toplevel
-    from frequenz.api.common.v1 import location_pb2
+    from frequenz.api.common.v1.types import location_pb2
 
     assert location_pb2 is not None
 
     # pylint: disable=import-outside-toplevel
-    from frequenz.api.common.v1 import location_pb2_grpc
+    from frequenz.api.common.v1.types import location_pb2_grpc
 
     assert location_pb2_grpc is not None
 


### PR DESCRIPTION
closes #363 