### PR TITLE
Rename `TimeIntervalFilter` to `Interval`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -94,7 +94,7 @@ Added many new messages and enum values:
 
 - `types`
 
-    + `TimeIntervalFilter`: Message to standardize time interval filtering across APIs
+    + `Interval`: Message to standardize time interval filtering across APIs
 
         This uses `start_time` (inclusive) and `end_time` (exclusive) fields, aligning with ISO 8601 and common programming conventions.
 

--- a/proto/frequenz/api/common/v1/types/interval.proto
+++ b/proto/frequenz/api/common/v1/types/interval.proto
@@ -22,7 +22,7 @@ import "google/protobuf/timestamp.proto";
 //   considered unbounded at the start.
 // * If `end_time` is omitted, the interval is
 //   considered unbounded at the end.
-message TimeIntervalFilter {
+message Interval {
   // The beginning of the time interval (inclusive).
   //
   // Must be a UTC timestamp.


### PR DESCRIPTION
This commit makes the name more generic, expressing its potential use-cases beyond filters.

closes #364 