### PR TITLE
Rename package `types` to `type`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -57,6 +57,10 @@
        * `METRIC_AC_ACTIVE_ENERGY*` to `METRIC_AC_ENERGY_ACTIVE*`
        * `METRIC_AC_REACTIVE_ENERGY*` to `METRIC_AC_ENERGY_REACTIVE*`
 
+    + `types`:
+
+        * The whole package has been renamed to `type`.
+
 - Renumbered some enum values to remove unnecessary gaps:
 
     + `microgrid.components.ComponentCategory` (`microgrid.electrical_components.ElectricalComponentCategory`)

--- a/proto/frequenz/api/common/v1/market/energy.proto
+++ b/proto/frequenz/api/common/v1/market/energy.proto
@@ -9,7 +9,7 @@ syntax = "proto3";
 
 package frequenz.api.common.v1.market;
 
-import "frequenz/api/common/v1/types/decimal.proto";
+import "frequenz/api/common/v1/type/decimal.proto";
 
 // Represents a single unit of electricity.
 //
@@ -20,5 +20,5 @@ import "frequenz/api/common/v1/types/decimal.proto";
 //     production or consumption.
 message Energy {
   // Energy unit in Megawatthours (MWh).
-  frequenz.api.common.v1.types.Decimal mwh = 1;
+  frequenz.api.common.v1.type.Decimal mwh = 1;
 }

--- a/proto/frequenz/api/common/v1/market/power.proto
+++ b/proto/frequenz/api/common/v1/market/power.proto
@@ -9,7 +9,7 @@ syntax = "proto3";
 
 package frequenz.api.common.v1.market;
 
-import "frequenz/api/common/v1/types/decimal.proto";
+import "frequenz/api/common/v1/type/decimal.proto";
 
 // Represents a single unit of power.
 //
@@ -26,5 +26,5 @@ import "frequenz/api/common/v1/types/decimal.proto";
 // market applications.
 message Power {
   // Power amount in Megawatts (MW).
-  frequenz.api.common.v1.types.Decimal mw = 1;
+  frequenz.api.common.v1.type.Decimal mw = 1;
 }

--- a/proto/frequenz/api/common/v1/market/price.proto
+++ b/proto/frequenz/api/common/v1/market/price.proto
@@ -9,7 +9,7 @@ syntax = "proto3";
 
 package frequenz.api.common.v1.market;
 
-import "frequenz/api/common/v1/types/decimal.proto";
+import "frequenz/api/common/v1/type/decimal.proto";
 
 // Represents a monetary price for electricity trading, including
 // the amount and currency. The currency used should align with the
@@ -46,7 +46,7 @@ message Price {
   }
 
   // The amount of the price.
-  frequenz.api.common.v1.types.Decimal amount = 1;
+  frequenz.api.common.v1.type.Decimal amount = 1;
 
   // The currency in which the price is denominated.
   Currency currency = 2;

--- a/proto/frequenz/api/common/v1/microgrid/microgrid.proto
+++ b/proto/frequenz/api/common/v1/microgrid/microgrid.proto
@@ -10,7 +10,7 @@ syntax = "proto3";
 package frequenz.api.common.v1.microgrid;
 
 import "frequenz/api/common/v1/grid/delivery_area.proto";
-import "frequenz/api/common/v1/types/location.proto";
+import "frequenz/api/common/v1/type/location.proto";
 
 import "google/protobuf/timestamp.proto";
 
@@ -60,7 +60,7 @@ message Microgrid {
   // Physical location of the microgrid, in geographical co-ordinates.
   //
   // If the location is not known, this field will be missing.
-  frequenz.api.common.v1.types.Location location = 5;
+  frequenz.api.common.v1.type.Location location = 5;
 
   // The current status of the microgrid.
   MicrogridStatus status = 6;

--- a/proto/frequenz/api/common/v1/type/decimal.proto
+++ b/proto/frequenz/api/common/v1/type/decimal.proto
@@ -7,7 +7,7 @@
 
 syntax = "proto3";
 
-package frequenz.api.common.v1.types;
+package frequenz.api.common.v1.type;
 
 // protolint:disable MAX_LINE_LENGTH
 // (the link is too long)

--- a/proto/frequenz/api/common/v1/type/interval.proto
+++ b/proto/frequenz/api/common/v1/type/interval.proto
@@ -7,7 +7,7 @@
 
 syntax = "proto3";
 
-package frequenz.api.common.v1.types;
+package frequenz.api.common.v1.type;
 
 import "google/protobuf/timestamp.proto";
 

--- a/proto/frequenz/api/common/v1/type/location.proto
+++ b/proto/frequenz/api/common/v1/type/location.proto
@@ -7,7 +7,7 @@
 
 syntax = "proto3";
 
-package frequenz.api.common.v1.types;
+package frequenz.api.common.v1.type;
 
 // A pair of geographical co-ordinates, representing the location of a place.
 message Location {

--- a/pytests/test_common.py
+++ b/pytests/test_common.py
@@ -15,12 +15,12 @@ def test_package_import() -> None:
 def test_module_import_decimal() -> None:
     """Test that the modules can be imported."""
     # pylint: disable=import-outside-toplevel
-    from frequenz.api.common.v1.types import decimal_pb2
+    from frequenz.api.common.v1.type import decimal_pb2
 
     assert decimal_pb2 is not None
 
     # pylint: disable=import-outside-toplevel
-    from frequenz.api.common.v1.types import decimal_pb2_grpc
+    from frequenz.api.common.v1.type import decimal_pb2_grpc
 
     assert decimal_pb2_grpc is not None
 
@@ -212,12 +212,12 @@ def test_module_import_microgrid_communication_components() -> None:
 def test_module_import_location() -> None:
     """Test that the modules can be imported."""
     # pylint: disable=import-outside-toplevel
-    from frequenz.api.common.v1.types import location_pb2
+    from frequenz.api.common.v1.type import location_pb2
 
     assert location_pb2 is not None
 
     # pylint: disable=import-outside-toplevel
-    from frequenz.api.common.v1.types import location_pb2_grpc
+    from frequenz.api.common.v1.type import location_pb2_grpc
 
     assert location_pb2_grpc is not None
 


### PR DESCRIPTION
This commit:
- Renames the directory `proto/frequenz/api/common/v1/types` to `proto/frequenz/api/common/v1/type` ..
- .. along with renaming the corresponding package from `types` to `type`.

This is done to use the same standards as google, potentially making it more familiar to users.

closes #365 