### PR TITLE
Rename sensor and electrical component telemetry states

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -28,6 +28,7 @@
         * `ComponentState` to `ElectricalComponentStateSnapshot`
         * `ComponentState.sampled_at` to `ElectricalComponentStateSnapshot.origin_time`
         * `ComponentData` to `ElectricalComponentTelemetry` (to better specify its purpose of encapsulating general telemetry data from electrical components)
+        * `ComponentData.states` to `ElectricalComponentTelemetry.state_snapshots`
         * Grid-related terms to clarify their meaning and purpose:
 
             + `COMPONENT_CATEGORY_GRID` to `ELECTRICAL_COMPONENT_CATEGORY_GRID_CONNECTION_POINT`
@@ -38,6 +39,7 @@
         * `SensorErrorCode` to `SensorDiagnosticCode`
         * `SensorData` to `SensorTelemetry` (to better specify its purpose of encapsulating general telemetry data from sensors)
         * `SensorState` to `SensorStateSnapshot`
+        * `SensorData.states` to `SensorTelemetry.state_snapshots`
         * `SensorState.sampled_at` to `SensorStateSnapshot.origin_time`
         * `SensorStateCode.SENSOR_STATE_CODE_ON` to `SensorStateCode.SENSOR_STATE_CODE_OK` (to better indicate that we do not control on/off state of sensors)
 

--- a/proto/frequenz/api/common/v1/microgrid/electrical_components/electrical_components.proto
+++ b/proto/frequenz/api/common/v1/microgrid/electrical_components/electrical_components.proto
@@ -580,6 +580,6 @@ message ElectricalComponentTelemetry {
   // List of measurements for a metric of the specific microgrid component.
   repeated frequenz.api.common.v1.metrics.MetricSample metric_samples = 2;
 
-  // List of states of a specific microgrid component.
-  repeated ElectricalComponentStateSnapshot states = 3;
+  // List of state snapshots of a specific microgrid component.
+  repeated ElectricalComponentStateSnapshot state_snapshots = 3;
 }

--- a/proto/frequenz/api/common/v1/microgrid/sensors/sensors.proto
+++ b/proto/frequenz/api/common/v1/microgrid/sensors/sensors.proto
@@ -182,7 +182,7 @@ message SensorTelemetry {
   // sensors.
   repeated frequenz.api.common.v1.metrics.MetricSample metric_samples = 2;
 
-  // List of states of a specific microgrid sensor.
-  repeated SensorStateSnapshot states = 3;
+  // List of state snapshots of a specific microgrid sensor.
+  repeated SensorStateSnapshot state_snapshots = 3;
 }
 


### PR DESCRIPTION
This commit renames the following:
- `ComponentData.state` to `ElectricalComponentTelemetry.state_snapshots`
- `SensorData.states` to `SensorTelemetry.state_snapshots`

closes #366 