### PR TITLE
Rename `INVERTER_TYPE_SOLAR` to `INVERTER_TYPE_PHOTOVOLTAIC`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -33,6 +33,7 @@
 
             + `COMPONENT_CATEGORY_GRID` to `ELECTRICAL_COMPONENT_CATEGORY_GRID_CONNECTION_POINT`
             + `ComponentCategoryMetadataVariant.metadata.grid` to `ElectricalComponentCategorySpecificInfo.kind.grid_connection_point`
+        * `InverterType.INVERTER_TYPE_SOLAR` to `InverterType.INVERTER_TYPE_PHOTOVOLTAIC` (to align with the more colloquial term "PV inverter", but without using abbreviations)
 
     + `microgrid.sensors`:
 

--- a/proto/frequenz/api/common/v1/microgrid/electrical_components/inverter.proto
+++ b/proto/frequenz/api/common/v1/microgrid/electrical_components/inverter.proto
@@ -18,8 +18,8 @@ enum InverterType {
   // Battery inverter.
   INVERTER_TYPE_BATTERY = 1;
 
-  // Solar inverter.
-  INVERTER_TYPE_SOLAR = 2;
+  // Photovoltaic (PV) inverter.
+  INVERTER_TYPE_PHOTOVOLTAIC = 2;
 
   // Hybrid inverter.
   INVERTER_TYPE_HYBRID = 3;


### PR DESCRIPTION
This commit renames the enum variant `InverterType.INVERTER_TYPE_SOLAR` to `InverterType.INVERTER_TYPE_PHOTOVOLTAIC` in the `inverter.proto` file. This change is made to align with the more colloquial term "PV inverter", while avoiding the use of an abbreviation.