### PR TITLE
Override the default include path when generating protobuf files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@
 requires = [
   "setuptools == 80.9.0",
   "setuptools_scm[toml] == 8.3.1",
-  "frequenz-repo-config[api] == 0.13.4",
+  "frequenz-repo-config[api] == 0.13.5",
   # We need to pin the protobuf, grpcio and  grpcio-tools dependencies to make
   # sure the code is generated using the minimum supported versions, as older
   # versions can't work with code that was generated with newer versions.
@@ -63,7 +63,7 @@ dev-mkdocs = [
   "mkdocs-literate-nav == 0.6.2",
   "mkdocs-material == 9.6.14",
   "mkdocstrings[python] == 0.29.1",
-  "frequenz-repo-config[api] == 0.13.4",
+  "frequenz-repo-config[api] == 0.13.5",
 ]
 dev-mypy = [
   "mypy == 1.16.0",
@@ -71,7 +71,7 @@ dev-mypy = [
   # For checking the noxfile, docs/ script, and tests
   "frequenz-api-common[dev-mkdocs,dev-noxfile,dev-pytest]",
 ]
-dev-noxfile = ["nox == 2025.5.1", "frequenz-repo-config[api] == 0.13.4"]
+dev-noxfile = ["nox == 2025.5.1", "frequenz-repo-config[api] == 0.13.5"]
 dev-pylint = [
   "pylint == 3.3.7",
   # For checking the noxfile, docs/ script, and tests
@@ -79,7 +79,7 @@ dev-pylint = [
 ]
 dev-pytest = [
   "pytest == 8.3.5",
-  "frequenz-repo-config[extra-lint-examples] == 0.13.4",
+  "frequenz-repo-config[extra-lint-examples] == 0.13.5",
 ]
 dev = [
   "frequenz-api-common[dev-mkdocs,dev-flake8,dev-formatting,dev-mkdocs,dev-mypy,dev-noxfile,dev-pylint,dev-pytest]",
@@ -90,6 +90,12 @@ Changelog = "https://github.com/frequenz-floss/frequenz-api-common/releases"
 Issues = "https://github.com/frequenz-floss/frequenz-api-common/issues"
 Repository = "https://github.com/frequenz-floss/frequenz-api-common"
 Support = "https://github.com/frequenz-floss/frequenz-api-common/discussions/categories/support"
+
+[tool.frequenz-repo-config.protobuf]
+# We need to explicitly set this to an empty array because repo-config will
+# automatically add `submodules/frequenz-api-common` as a include, but this is
+# us, and we don't include ourselves as a submodule.
+include_paths = []
 
 [tool.black]
 line-length = 88


### PR DESCRIPTION
By default `repo-config` will include the `submodules/frequenz-api-common` directory, which is us, and we don't want to include ourselves as a submodule, so we need to explicitly set the `include_paths` to an empty array.

We also need to bump the dependency on `frequenz-repo-config` to get a bug fix that allows overriding with an empty array.
