### PR TITLE
Remove `InverterType.INVERTER_TYPE_WIND_TURBINE`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,7 @@
 
 - A new package `frequenz.api.common.v1alpha8` has been added. It has the following changes when compared to `frequenz.api.common.v1alpha7`:
   - `electrical_components.Fuse` has been removed.
+  - `InverterType.INVERTER_TYPE_WIND_TURBINE` has been removed.
 
 ## Bug Fixes
 

--- a/proto/frequenz/api/common/v1alpha8/microgrid/electrical_components/electrical_components.proto
+++ b/proto/frequenz/api/common/v1alpha8/microgrid/electrical_components/electrical_components.proto
@@ -526,9 +526,6 @@ enum InverterType {
 
   // Hybrid inverter.
   INVERTER_TYPE_HYBRID = 3;
-
-  // Wind turbine inverter.
-  INVERTER_TYPE_WIND_TURBINE = 4;
 }
 
 // A representation of an inverter.


### PR DESCRIPTION
Wind turbines typically do AC->DC->AC conversion, so classifying them as inverters is not appropriate. Additionally, a component category `COMPONENT_CATEGORY_WIND_TURBINE` already exists to represent wind turbines, so it is redundant to have a separate inverter type for them.