### PR TITLE
Rename leftover uses of `component_id` to `electrical_component_id`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,10 @@
 - A new package `frequenz.api.common.v1alpha8` has been added. It has the following changes when compared to `frequenz.api.common.v1alpha7`:
   - `electrical_components.Fuse` has been removed.
   - `InverterType.INVERTER_TYPE_WIND_TURBINE` has been removed.
+  - `ElectricalComponentConnections.source_component_id` has been renamed to `ElectricalComponentConnections.source_electrical_component_id`
+  - `ElectricalComponentConnections.destination_component_id` has been renamed to `ElectricalComponentConnections.destination_electrical_component_id`
+  - `ElectricalComponentStateSnapshot.component_id` has been renamed to `ElectricalComponentStateSnapshot.electrical_component_id`
+
 
 ## Bug Fixes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,6 +16,8 @@
   - `ElectricalComponentConnections.source_component_id` has been renamed to `ElectricalComponentConnections.source_electrical_component_id`
   - `ElectricalComponentConnections.destination_component_id` has been renamed to `ElectricalComponentConnections.destination_electrical_component_id`
   - `ElectricalComponentStateSnapshot.component_id` has been renamed to `ElectricalComponentStateSnapshot.electrical_component_id`
+  - `microgrid.MicrogridComponentIds` has been renamed to `microgrid.MicrogridElectricalComponentIds`.
+  - `MicrogridComponentIDs.component_ids` has been renamed to `MicrogridElectricalComponentIds.electrical_component_ids`.
 
 
 ## Bug Fixes

--- a/proto/frequenz/api/common/v1alpha8/microgrid/electrical_components/electrical_components.proto
+++ b/proto/frequenz/api/common/v1alpha8/microgrid/electrical_components/electrical_components.proto
@@ -753,7 +753,7 @@ message ElectricalComponentStateSnapshot {
 //          connection: "pv_0"
 //        }
 //      ],
-//      states: [
+//      state_snapshots: [
 //        /* list of states for multiple timestamps */
 //        {
 //          sample_time: "2023-10-01T00:00:00Z",

--- a/proto/frequenz/api/common/v1alpha8/microgrid/electrical_components/electrical_components.proto
+++ b/proto/frequenz/api/common/v1alpha8/microgrid/electrical_components/electrical_components.proto
@@ -638,11 +638,11 @@ message ElectricalComponentConnection {
   // Unique identifier of the component where the connection originates. This is
   // aligned with the direction of current flow away from the grid connection
   // point, or in case of islands, away from the islanding point.
-  uint64 source_component_id = 1;
+  uint64 source_electrical_component_id = 1;
 
   // Unique ID of the component where the connection terminates. This is the
   // component towards which the current flows.
-  uint64 destination_component_id = 2;
+  uint64 destination_electrical_component_id = 2;
 
   // The operational lifetime of the connection.
   frequenz.api.common.v1alpha8.microgrid.Lifetime operational_lifetime = 3;
@@ -728,13 +728,14 @@ message ElectricalComponentStateSnapshot {
 }
 
 // ElectricalComponentTelemetry message aggregates multiple metrics, operational
-// states, and errors, related to a specific microgrid component.
+// states, and errors, related to a specific electrical component in a
+// microgrid.
 //
 // !!! example
-//   Example output of a component data message:
+//   Example output of a telemetry message:
 //   ```
 //    {
-//      component_id: 13,
+//      electrical_component_id: 13,
 //      metric_samples: [
 //        /* list of metrics for multiple timestamps */
 //        {
@@ -770,12 +771,13 @@ message ElectricalComponentStateSnapshot {
 //    }
 //  ```
 message ElectricalComponentTelemetry {
-  // The ID of the microgrid component.
-  uint64 component_id = 1;
+  // The ID of the electrical component for which the telemetry is
+  // collected.
+  uint64 electrical_component_id = 1;
 
-  // List of measurements for a metric of the specific microgrid component.
+  // List of measurements for a metric of the specific electrical component.
   repeated frequenz.api.common.v1alpha8.metrics.MetricSample metric_samples = 2;
 
-  // List of state snapshots of a specific microgrid component.
+  // List of state snapshots of a specific electrical component.
   repeated ElectricalComponentStateSnapshot state_snapshots = 3;
 }

--- a/proto/frequenz/api/common/v1alpha8/microgrid/microgrid.proto
+++ b/proto/frequenz/api/common/v1alpha8/microgrid/microgrid.proto
@@ -69,13 +69,14 @@ message Microgrid {
   google.protobuf.Timestamp create_timestamp = 7;
 }
 
-// A message to link component IDs with their respective microgrid ID.
-message MicrogridComponentIDs {
+// A message to link electrical component IDs with their respective microgrid
+// ID.
+message MicrogridElectricalComponentIDs {
   // The ID of the microgrid.
   uint64 microgrid_id = 1;
 
-  // List of component IDs belonging to this microgrid.
-  repeated uint64 component_ids = 2;
+  // List of electrical component IDs belonging to this microgrid.
+  repeated uint64 electrical_component_ids = 2;
 }
 
 /// A message to link sensor IDs with their respective microgrid ID.

--- a/proto/frequenz/api/common/v1alpha8/microgrid/sensors/sensors.proto
+++ b/proto/frequenz/api/common/v1alpha8/microgrid/sensors/sensors.proto
@@ -162,7 +162,7 @@ message SensorStateSnapshot {
 //          connection: "humidity_sensor_1"
 //        }
 //      ],
-//      states: [
+//      state_snapshots: [
 //        {
 //          sample_time: "2023-10-01T00:00:00Z",
 //          states: [],


### PR DESCRIPTION
closes #395 