### PR TITLE
Rename voltage-transformer to power-transformer

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,6 +18,9 @@
   - `ElectricalComponentStateSnapshot.component_id` has been renamed to `ElectricalComponentStateSnapshot.electrical_component_id`
   - `microgrid.MicrogridComponentIds` has been renamed to `microgrid.MicrogridElectricalComponentIds`.
   - `MicrogridComponentIDs.component_ids` has been renamed to `MicrogridElectricalComponentIds.electrical_component_ids`.
+  - `electrical_components.VoltageTransformer` has been renamed to `electrical_components.PowerTransformer`, to make the name more consistent with the underlying concept.
+  - `ElectricalComponentCategorySpecificInfo.kind.voltage_transformer` has been renamed to `ElectricalComponentCategorySpecificInfo.kind.power_transformer`, to make the name more consistent with the underlying concept.
+  - `ElectricalComponentCategory.ELECTRICAL_COMPONENT_CATEGORY_VOLTAGE_TRANSFORMER` has been renamed to `ElectricalComponentCategory.ELECTRICAL_COMPONENT_CATEGORY_POWER_TRANSFORMER`, to make the name more consistent with the underlying concept.
 
 
 ## Bug Fixes

--- a/proto/frequenz/api/common/v1alpha8/microgrid/electrical_components/electrical_components.proto
+++ b/proto/frequenz/api/common/v1alpha8/microgrid/electrical_components/electrical_components.proto
@@ -106,14 +106,16 @@ enum ElectricalComponentCategory {
   // Examples: Siemens Silyzer, Nel Hydrogen PEM, ITM Power electrolyzers.
   ELECTRICAL_COMPONENT_CATEGORY_ELECTROLYZER = 10;
 
-  // A voltage transformer.
+  // A power transformer.
   //
-  // Voltage transformers are used to step up or step down the voltage, keeping
-  // the power somewhat constant by increasing or decreasing the current.
-  // If voltage is stepped up, current is stepped down, and vice versa.
-  // Note that voltage transformers have efficiency losses, so the output power
-  // is always less than the input power.
-  ELECTRICAL_COMPONENT_CATEGORY_VOLTAGE_TRANSFORMER = 11;
+  // A power transformer is designed for the bulk transfer of electrical energy.
+  // Its main job is to "step-up" or "step-down" voltage levels for efficient
+  // transmission and distribution of power.
+  //
+  // Since power transformers try to keep the output power same as the input
+  // power (ignoring losses), when they step-up the voltage, the current gets
+  // proportionally reduced, and vice versa.
+  ELECTRICAL_COMPONENT_CATEGORY_POWER_TRANSFORMER = 11;
 
   // An HVAC system (Heating, Ventilation, and Air Conditioning).
   //
@@ -535,13 +537,18 @@ message Inverter {
   InverterType type = 1;
 }
 
-// A representation of a voltage transformer.
-// Voltage transformers are used to step up or step down the voltage, keeping
-// the power somewhat constant by increasing or decreasing the current.
-// If voltage is stepped up, current is stepped down, and vice versa.
-// Note that voltage transformers have efficiency losses, so the output power
-// is always less than the input power.
-message VoltageTransformer {
+// A representation of a power transformer.
+//
+// The voltage across the secondary winding of a power transformer is
+// typically equal to the voltage across the primary winding multiplied by the
+// primary/secondary turns ratio. The current flowing through the secondary
+// winding is typically equal to the current flowing through the primary
+// winding multiplied by the secondary/primary turns ratio, ignoring losses.
+//
+// If the voltage across the secondary winding is greater than the voltage
+// across the primary winding, the transformer is said to step-up the voltage,
+// otherwise it is said to step-down the voltage.
+message PowerTransformer {
   // The primary voltage of the transformer.
   // This is the input voltage that is stepped up or down.
   float primary = 1;
@@ -577,7 +584,7 @@ message ElectricalComponentCategorySpecificInfo {
     EvCharger ev_charger = 2;
     GridConnectionPoint grid_connection_point = 3;
     Inverter inverter = 4;
-    VoltageTransformer voltage_transformer = 5;
+    PowerTransformer power_transformer = 5;
   }
 }
 


### PR DESCRIPTION
Voltage-transformers  are used in voltmeters for pretection, whereas what we needed was a power transformer, which is used for bulk transfer of electrical energy with voltage stepping up or down.

This renaming makes the electrical component name more consistent with the underlying concept of the component.