### PR TITLE
Rename `type` package to `types` in v1alpha8 proto files

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,6 +21,7 @@
   - `electrical_components.VoltageTransformer` has been renamed to `electrical_components.PowerTransformer`, to make the name more consistent with the underlying concept.
   - `ElectricalComponentCategorySpecificInfo.kind.voltage_transformer` has been renamed to `ElectricalComponentCategorySpecificInfo.kind.power_transformer`, to make the name more consistent with the underlying concept.
   - `ElectricalComponentCategory.ELECTRICAL_COMPONENT_CATEGORY_VOLTAGE_TRANSFORMER` has been renamed to `ElectricalComponentCategory.ELECTRICAL_COMPONENT_CATEGORY_POWER_TRANSFORMER`, to make the name more consistent with the underlying concept.
+  - The `type` package has been renamed to `types`, to avoid using reserved keywords in programming languages.
 
 
 ## Bug Fixes

--- a/proto/frequenz/api/common/v1alpha8/market/energy.proto
+++ b/proto/frequenz/api/common/v1alpha8/market/energy.proto
@@ -9,7 +9,7 @@ syntax = "proto3";
 
 package frequenz.api.common.v1alpha8.market;
 
-import "frequenz/api/common/v1alpha8/type/decimal.proto";
+import "frequenz/api/common/v1alpha8/types/decimal.proto";
 
 // Represents a single unit of electricity.
 //
@@ -20,5 +20,5 @@ import "frequenz/api/common/v1alpha8/type/decimal.proto";
 //     production or consumption.
 message Energy {
   // Energy unit in Megawatthours (MWh).
-  frequenz.api.common.v1alpha8.type.Decimal mwh = 1;
+  frequenz.api.common.v1alpha8.types.Decimal mwh = 1;
 }

--- a/proto/frequenz/api/common/v1alpha8/market/power.proto
+++ b/proto/frequenz/api/common/v1alpha8/market/power.proto
@@ -9,7 +9,7 @@ syntax = "proto3";
 
 package frequenz.api.common.v1alpha8.market;
 
-import "frequenz/api/common/v1alpha8/type/decimal.proto";
+import "frequenz/api/common/v1alpha8/types/decimal.proto";
 
 // Represents a single unit of power.
 //
@@ -26,5 +26,5 @@ import "frequenz/api/common/v1alpha8/type/decimal.proto";
 // market applications.
 message Power {
   // Power amount in Megawatts (MW).
-  frequenz.api.common.v1alpha8.type.Decimal mw = 1;
+  frequenz.api.common.v1alpha8.types.Decimal mw = 1;
 }

--- a/proto/frequenz/api/common/v1alpha8/market/price.proto
+++ b/proto/frequenz/api/common/v1alpha8/market/price.proto
@@ -9,7 +9,7 @@ syntax = "proto3";
 
 package frequenz.api.common.v1alpha8.market;
 
-import "frequenz/api/common/v1alpha8/type/decimal.proto";
+import "frequenz/api/common/v1alpha8/types/decimal.proto";
 
 // Represents a monetary price for electricity trading, including
 // the amount and currency. The currency used should align with the
@@ -46,7 +46,7 @@ message Price {
   }
 
   // The amount of the price.
-  frequenz.api.common.v1alpha8.type.Decimal amount = 1;
+  frequenz.api.common.v1alpha8.types.Decimal amount = 1;
 
   // The currency in which the price is denominated.
   Currency currency = 2;

--- a/proto/frequenz/api/common/v1alpha8/microgrid/microgrid.proto
+++ b/proto/frequenz/api/common/v1alpha8/microgrid/microgrid.proto
@@ -10,7 +10,7 @@ syntax = "proto3";
 package frequenz.api.common.v1alpha8.microgrid;
 
 import "frequenz/api/common/v1alpha8/grid/delivery_area.proto";
-import "frequenz/api/common/v1alpha8/type/location.proto";
+import "frequenz/api/common/v1alpha8/types/location.proto";
 
 import "google/protobuf/timestamp.proto";
 
@@ -60,7 +60,7 @@ message Microgrid {
   // Physical location of the microgrid, in geographical co-ordinates.
   //
   // If the location is not known, this field will be missing.
-  frequenz.api.common.v1alpha8.type.Location location = 5;
+  frequenz.api.common.v1alpha8.types.Location location = 5;
 
   // The current status of the microgrid.
   MicrogridStatus status = 6;

--- a/proto/frequenz/api/common/v1alpha8/types/decimal.proto
+++ b/proto/frequenz/api/common/v1alpha8/types/decimal.proto
@@ -7,7 +7,7 @@
 
 syntax = "proto3";
 
-package frequenz.api.common.v1alpha8.type;
+package frequenz.api.common.v1alpha8.types;
 
 // protolint:disable MAX_LINE_LENGTH
 // (the link is too long)

--- a/proto/frequenz/api/common/v1alpha8/types/interval.proto
+++ b/proto/frequenz/api/common/v1alpha8/types/interval.proto
@@ -7,7 +7,7 @@
 
 syntax = "proto3";
 
-package frequenz.api.common.v1alpha8.type;
+package frequenz.api.common.v1alpha8.types;
 
 import "google/protobuf/timestamp.proto";
 

--- a/proto/frequenz/api/common/v1alpha8/types/location.proto
+++ b/proto/frequenz/api/common/v1alpha8/types/location.proto
@@ -7,7 +7,7 @@
 
 syntax = "proto3";
 
-package frequenz.api.common.v1alpha8.type;
+package frequenz.api.common.v1alpha8.types;
 
 // A pair of geographical co-ordinates, representing the location of a place.
 message Location {

--- a/py/frequenz/api/common/v1alpha8/type/__init__.py
+++ b/py/frequenz/api/common/v1alpha8/type/__init__.py
@@ -1,4 +1,0 @@
-# License: MIT
-# Copyright © 2025 Frequenz Energy-as-a-Service GmbH
-
-"""Type bindings for Frequenz common gRPC API."""

--- a/pytests/test_common_v1alpha8.py
+++ b/pytests/test_common_v1alpha8.py
@@ -15,12 +15,12 @@ def test_package_import() -> None:
 def test_module_import_decimal() -> None:
     """Test that the modules can be imported."""
     # pylint: disable=import-outside-toplevel
-    from frequenz.api.common.v1alpha8.type import decimal_pb2
+    from frequenz.api.common.v1alpha8.types import decimal_pb2
 
     assert decimal_pb2 is not None
 
     # pylint: disable=import-outside-toplevel
-    from frequenz.api.common.v1alpha8.type import decimal_pb2_grpc
+    from frequenz.api.common.v1alpha8.types import decimal_pb2_grpc
 
     assert decimal_pb2_grpc is not None
 
@@ -148,12 +148,12 @@ def test_module_import_microgrid_communication_components() -> None:
 def test_module_import_location() -> None:
     """Test that the modules can be imported."""
     # pylint: disable=import-outside-toplevel
-    from frequenz.api.common.v1alpha8.type import location_pb2
+    from frequenz.api.common.v1alpha8.types import location_pb2
 
     assert location_pb2 is not None
 
     # pylint: disable=import-outside-toplevel
-    from frequenz.api.common.v1alpha8.type import location_pb2_grpc
+    from frequenz.api.common.v1alpha8.types import location_pb2_grpc
 
     assert location_pb2_grpc is not None
 


### PR DESCRIPTION
This commit renames the `type` package to `types` in the v1alpha8 proto files to avoid using reserved keywords in programming languages.