### PR TITLE
Add a new variant `Meter` to `ElectricalComponentCategorySpecificInfo`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,34 +2,16 @@
 
 ## Summary
 
-This release introduces the new `v1alpha8` version of the API, which includes several breaking changes compared to `v1alpha7`. The changes focus on improving consistency and clarity by renaming several symbols and removing unused components.
+<!-- Here goes a general summary of what this release is about -->
 
 ## Upgrading
 
-- A new package `frequenz.api.common.v1alpha8` has been introduced, containing the following breaking changes from `v1alpha7`.
+<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
 
-- Removed:
+## New Features
 
-    + `electrical_components.Fuse`
-    + `InverterType.INVERTER_TYPE_WIND_TURBINE`
+<!-- Here goes the main new features and examples or instructions on how to use them -->
 
-- Renamed several symbols to increase consistency and clarity:
+## Bug Fixes
 
-    + `microgrid`:
-
-        * `MicrogridComponentIds` to `MicrogridElectricalComponentIds`
-        * `MicrogridComponentIDs.component_ids` to `MicrogridElectricalComponentIds.electrical_component_ids`
-
-    + `electrical_components`:
-
-        * `ElectricalComponentConnections.source_component_id` to `ElectricalComponentConnections.source_electrical_component_id`
-        * `ElectricalComponentConnections.destination_component_id` to `ElectricalComponentConnections.destination_electrical_component_id`
-        * `ElectricalComponentStateSnapshot.component_id` to `ElectricalComponentStateSnapshot.electrical_component_id`
-        * Transformer-related terms are renamed to align them with power transformers, which are more commonly used in electrical engineering:
-            * `electrical_components.VoltageTransformer` to `electrical_components.PowerTransformer`
-            * `ElectricalComponentCategorySpecificInfo.kind.voltage_transformer` to `ElectricalComponentCategorySpecificInfo.kind.power_transformer`
-            * `ElectricalComponentCategory.ELECTRICAL_COMPONENT_CATEGORY_VOLTAGE_TRANSFORMER` to `ElectricalComponentCategory.ELECTRICAL_COMPONENT_CATEGORY_POWER_TRANSFORMER`
-
-    + `types`:
-
-        * The whole package has been renamed to `types` to avoid using reserved keywords in programming languages.
+<!-- Here goes notable bug fixes that are worth a special mention or explanation -->

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,8 @@
 
 ## New Features
 
-<!-- Here goes the main new features and examples or instructions on how to use them -->
+- A new message has been added to the `v1alpha8` package: `microgrid.electrical_components.Meter`. This message holds static information about specific meters in a microgrid.
+- The `microgrid.electrical_components.ElectricalComponentCategorySpecificInfo` enum in the `v1alpha8` package has been extended with a new variant: `Meter`. This addition allows expressing information specific to meters within a microgrid.
 
 ## Bug Fixes
 

--- a/proto/frequenz/api/common/v1alpha8/microgrid/electrical_components/electrical_components.proto
+++ b/proto/frequenz/api/common/v1alpha8/microgrid/electrical_components/electrical_components.proto
@@ -559,6 +559,25 @@ message PowerTransformer {
   float secondary = 2;
 }
 
+// A representation of a meter.
+//
+// Meters typically cannot be controlled remotely, but they can provide
+// telemetry data.
+message Meter {
+  // Indicates if the polarity of the meter is reversed.
+  //
+  // During installation, meters may be wired in an opposite direction, causing
+  // consumption to be reported as negative values, and production as positive
+  // values. Since this is opposite to the convention followed in this API -
+  // consumption is positive, and production is negative - it is important to
+  // know if such a reversal is present.
+  //
+  // If true, the telemetry values reported by the meter should be inverted
+  // (multiplied by -1) to reflect the correct polarity - consumption as
+  // positive, and production as negative.
+  bool polarity_reversed = 1;
+}
+
 // MetricConfigBounds describes a set of limits for a specific metric consisting
 // of a lower and upper bound for said metric.
 //
@@ -585,6 +604,7 @@ message ElectricalComponentCategorySpecificInfo {
     GridConnectionPoint grid_connection_point = 3;
     Inverter inverter = 4;
     PowerTransformer power_transformer = 5;
+    Meter meter = 6;
   }
 }
 


### PR DESCRIPTION
This commit introduces a new message `Meter` to the `v1alpha8` package, which encapsulates static information about meters in a microgrid. Additionally, the `ElectricalComponentCategorySpecificInfo` enum has been extended to include the `Meter` variant. This enhancement enables the representation of meter-specific information within a microgrid.