### PR TITLE
feat: Add Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/auto-dependabot.yaml
+++ b/.github/workflows/auto-dependabot.yaml
@@ -1,0 +1,18 @@
+name: Dependabot Auto Manage
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - uses: ad/dependabot-auto-approve@v1
+        with:
+          dependency-type: 'all'
+          auto-merge: 'true'
+          add-label: 'auto-merged'
+          merge-method: 'merge'


### PR DESCRIPTION
This PR adds a GitHub workflow to automatically manage Dependabot pull requests.

This workflow uses the `ad/dependabot-auto-approve@v1` GitHub Action, which may need to be explicitly whitelisted in the organization's settings.