### PR TITLE
Add component category: Steam boiler

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,7 @@
 
 ## New Features
 
-<!-- Here goes the main new features and examples or instructions on how to use them -->
+A new component category for electric steam boilers has been added. The use case we're adding this for is a hybrid (gas/electric) steam boiler that may switch/blend between power sources and takes _available_ electric power into consideration.
 
 ## Bug Fixes
 

--- a/proto/frequenz/api/common/v1alpha8/microgrid/electrical_components/electrical_components.proto
+++ b/proto/frequenz/api/common/v1alpha8/microgrid/electrical_components/electrical_components.proto
@@ -174,6 +174,13 @@ enum ElectricalComponentCategory {
   // regulation, and status.
   // Examples: Siemens Gamesa SG, Vestas V series, GE Cypress, Nordex Delta.
   ELECTRICAL_COMPONENT_CATEGORY_WIND_TURBINE = 18;
+
+  // A steam boiler.
+  //
+  // Generates steam from electricity.
+  // Hybrid steam boilers may switch/blend between electricity and gas power.
+  // Examples: Bosch ELSB4x16.
+  ELECTRICAL_COMPONENT_CATEGORY_STEAM_BOILER = 19;
 }
 
 // Enum to represent the various states that a component can be in.


### PR DESCRIPTION
This change adds a new component category for electric steam boilers.

Context: https://github.com/frequenz-io/core/issues/430