### PR TITLE
Add model field to ElectricalComponent and Sensor messages

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,11 @@
 
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
+- The following fields have been deprecated in the package `v1alpha8`, and will be removed in a future release:
+  - `microgrid.electrical_components.ElectricalComponent.manufacturer` (string): The manufacturer of the electrical component.
+  - `microgrid.electrical_components.ElectricalComponent.model_number` (string): The model number of the electrical component.
+  - `microgrid.sensors.Sensor.manufacturer` (string): The manufacturer of the sensor.
+  - `microgrid.sensors.Sensor.model_number` (string): The model number of the sensor.
 
 ## New Features
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,8 @@
 - The following new entities have been added to the package `v1alpha8`:
   - Enum `microgrid.electrical_components.ElectricalComponentOperationalMode`: Enumeration of the possible operational modes of an electrical component - inactive, telemetry-only, control-only, and control-and-telemetry.
   - Field `microgrid.electrical_components.ElectricalComponent.operational_mode`: Defines if an electrical component is active, if it provides telemetry data, and if it accepts control commands.
+  - Field `microgrid.electrical_components.ElectricalComponent.model`: The model name of the electrical component, including the manufacturer and model number.
+  - Field `microgrid.sensors.Sensor.model`: The model name of the sensor, including the manufacturer and model number.
 
 ## Bug Fixes
 

--- a/proto/frequenz/api/common/v1alpha8/microgrid/electrical_components/electrical_components.proto
+++ b/proto/frequenz/api/common/v1alpha8/microgrid/electrical_components/electrical_components.proto
@@ -637,10 +637,18 @@ message ElectricalComponent {
   ElectricalComponentCategorySpecificInfo category_specific_info = 5;
 
   // The component manufacturer.
-  string manufacturer = 6;
+  //
+  // Note that this field is deprecated and should not be used.
+  // Please use the `model` field instead, which includes both the manufacturer
+  // and the model name.
+  string manufacturer = 6 [deprecated = true];
 
   // The model name of the component.
-  string model_name = 7;
+  //
+  // Note that this field is deprecated and should not be used.
+  // Please use the `model` field instead, which includes both the manufacturer
+  // and the model name.
+  string model_name = 7 [deprecated = true];
 
   // The operational lifetime of the component.
   frequenz.api.common.v1alpha8.microgrid.Lifetime operational_lifetime = 8;

--- a/proto/frequenz/api/common/v1alpha8/microgrid/electrical_components/electrical_components.proto
+++ b/proto/frequenz/api/common/v1alpha8/microgrid/electrical_components/electrical_components.proto
@@ -652,6 +652,10 @@ message ElectricalComponent {
   // active and operational, and whether it provides telemetry data, accepts
   // control commands, or both.
   ElectricalComponentOperationalMode operational_mode = 10;
+
+  // The model name of the electrical component.
+  // Includes both the manufacturer and the model name.
+  string model = 11;
 }
 
 // ElectricalComponentConnection describes a single electrical link between two

--- a/proto/frequenz/api/common/v1alpha8/microgrid/sensors/sensors.proto
+++ b/proto/frequenz/api/common/v1alpha8/microgrid/sensors/sensors.proto
@@ -63,6 +63,10 @@ message Sensor {
 
   // The operational lifetime of the sensor.
   frequenz.api.common.v1alpha8.microgrid.Lifetime operational_lifetime = 7;
+
+  // The model name of the electrical component.
+  // Includes both the manufacturer and the model name.
+  string model = 8;
 }
 
 // Represents an error or warning condition reported by a microgrid sensor.

--- a/proto/frequenz/api/common/v1alpha8/microgrid/sensors/sensors.proto
+++ b/proto/frequenz/api/common/v1alpha8/microgrid/sensors/sensors.proto
@@ -55,11 +55,19 @@ message Sensor {
   // An optional name for the sensor.
   string name = 3;
 
-  // The sensor manufacturer.
-  string manufacturer = 5;
+  // The component manufacturer.
+  //
+  // Note that this field is deprecated and should not be used.
+  // Please use the `model` field instead, which includes both the manufacturer
+  // and the model name.
+  string manufacturer = 5 [deprecated = true];
 
-  // The model name of the sensor.
-  string model_name = 6;
+  // The model name of the component.
+  //
+  // Note that this field is deprecated and should not be used.
+  // Please use the `model` field instead, which includes both the manufacturer
+  // and the model name.
+  string model_name = 6 [deprecated = true];
 
   // The operational lifetime of the sensor.
   frequenz.api.common.v1alpha8.microgrid.Lifetime operational_lifetime = 7;


### PR DESCRIPTION
This PR adds a new field `model` to the `ElectricalComponent` and `Sensor` messages in the proto files. The `model` field includes both the manufacturer and the model name of the component or sensor.

Typically, the existing fields `manufacturer` and `model_name` are not used in separate contexts, despite being present in the structure for years. The new `model` field provides a more concise way to represent the model information, which is often used in practice.

In addition to the above, this PR deprecates the existing fields `manufacturer` and `model_name`, and these fields be removed in the next breaking change release.