### PR TITLE
dependabot: Add a migration script for grpc updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,11 @@ updates:
         exclude-patterns:
           # pydoclint has shipped breaking changes in patch updates often
           - "pydoclint"
+          # These need a migration script to fix dependabot missing updating
+          # the runtime dependencies
+          - "grpcio"
+          - "grpcio-tools"
+          - "protobuf"
       minor:
         update-types:
           - "minor"
@@ -61,11 +66,26 @@ updates:
           - "mkdocstrings[python]"
       # We group grpcio and protobuf updates together, as they need special
       # handling on the pyproject.toml file because of the protobuf/grpcio
-      # build/runtime cross-version guarantees
-      grpc:
+      # build/runtime cross-version guarantees and wrong dependabot handling
+      # of build/runtime dependencies.
+      grpc-compatible:
+        update-types:
+          - "patch"
+          - "minor"
         patterns:
           - "grpcio"
           - "grpcio-tools"
+          - "protobuf"
+      # For major updates we split it up. It was observed in the past that
+      # grpcio releases lag behind protobuf releases, and they are not
+      # compatible with a major protobuf update for a while, so we shouldn't
+      # block the update of one with the other.
+      grpcio-major:
+        patterns:
+          - "grpcio"
+          - "grpcio-tools"
+      protobuf-major:
+        patterns:
           - "protobuf"
 
   - package-ecosystem: "github-actions"

--- a/.github/workflows/auto-dependabot.yaml
+++ b/.github/workflows/auto-dependabot.yaml
@@ -23,6 +23,9 @@ jobs:
     if: >
       github.actor == 'dependabot[bot]' &&
       !contains(github.event.pull_request.title, 'the repo-config group') &&
+      !contains(github.event.pull_request.title, 'the grpc-compatible group') &&
+      !contains(github.event.pull_request.title, 'the grpcio-major group') &&
+      !contains(github.event.pull_request.title, 'the protobuf-major group') &&
       !contains(github.event.pull_request.title, 'Bump black from ')
     runs-on: ubuntu-slim
     steps:

--- a/.github/workflows/grpc-migration.yaml
+++ b/.github/workflows/grpc-migration.yaml
@@ -1,0 +1,221 @@
+# Automatic grpc/protobuf build/runtime sync for Dependabot PRs
+#
+# The template's `pyproject.toml` pins `protobuf`, `grpcio` and `grpcio-tools`
+# in `[build-system].requires` as *exact* versions, and also declares
+# `protobuf` and `grpcio` in `[project].dependencies` with a `>= <build-pin>`
+# lower bound.  The lower bound must always match the exact pin, because the
+# protobuf cross-version runtime guarantee requires the runtime to be at
+# least the version used at generation time:
+#   https://protobuf.dev/support/cross-version-runtime-guarantee/
+#
+# Dependabot correctly bumps `[build-system].requires`, but it does not bump
+# the matching `>=` floor in `[project].dependencies`.  This workflow runs
+# after a Dependabot `grpc` group PR, rewrites the `>=` floor to match the
+# new build pins, and pushes the fix-up commit back onto the PR branch.
+#
+# The companion auto-dependabot workflow skips the `grpc` group so those PRs
+# are handled exclusively by this migration workflow.
+#
+# XXX: !!! SECURITY WARNING !!!
+# pull_request_target has write access to the repo, and can read secrets.
+# This is required because Dependabot PRs are treated as fork PRs: the
+# GITHUB_TOKEN is read-only and secrets are unavailable with a plain
+# pull_request trigger.  The action mitigates the risk by:
+#   - Never executing code from the PR (the migration script is embedded
+#     in this workflow file on the base branch, not taken from the PR).
+#   - Gating migration steps on github.actor == 'dependabot[bot]' AND the
+#     PR title.
+#   - Running checkout with persist-credentials: false and isolating
+#     push credentials from the migration script environment.
+# For more details read:
+# https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+
+name: gRPC Migration
+
+on:
+  merge_group:  # To allow using this as a required check for merging
+  pull_request_target:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  # Commit the sync-up to the PR branch.
+  contents: write
+  # Create and normalize migration state labels.
+  issues: write
+  # Read/update pull request metadata and comments.
+  pull-requests: write
+
+jobs:
+  grpc-migration:
+    name: Fix gRPC/protobuf runtime floors
+    # Skip if it was triggered by the merge queue. We only need the workflow to
+    # be executed to meet the "Required check" condition for merging, but we
+    # don't need to actually run the job, having the job present as Skipped is
+    # enough.
+    if: |
+      github.event_name == 'pull_request_target' &&
+      github.actor == 'dependabot[bot]' &&
+      (contains(github.event.pull_request.title, 'the grpc-compatible group') ||
+       contains(github.event.pull_request.title, 'the grpcio-major group') ||
+       contains(github.event.pull_request.title, 'the protobuf-major group'))
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Generate token
+        id: create-app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        with:
+          app-id: ${{ secrets.FREQUENZ_AUTO_DEPENDABOT_APP_ID }}
+          private-key: ${{ secrets.FREQUENZ_AUTO_DEPENDABOT_APP_PRIVATE_KEY }}
+          # Push the sync-up commit to the PR branch.
+          permission-contents: write
+          # Create and normalize migration state labels.
+          permission-issues: write
+          # Read/update pull request metadata and labels.
+          permission-pull-requests: write
+      - name: Fetch Dependabot metadata
+        id: dependabot-metadata
+        # We pin a main-branch commit because v2.5.0 missed the grouped-
+        # update version fix, which left updated-dependencies-json incomplete.
+        # See:
+        # https://github.com/dependabot/fetch-metadata/issues/402
+        uses: dependabot/fetch-metadata@4c0bbfe3a642ee5826e71be3cb91cd949dc0a897  # main
+      - name: Print debug info
+        env:
+          UPDATED_DEPENDENCIES_JSON: ${{ steps.dependabot-metadata.outputs.updated-dependencies-json }}
+        run: |
+          echo "Updated dependencies JSON:"
+          echo "$UPDATED_DEPENDENCIES_JSON" | jq -C .
+      - name: Migrate
+        uses: frequenz-floss/gh-action-dependabot-migrate@b389f72f9282346920150a67495efbae450ac07b  # v1.1.0
+        env:
+          UPDATED_DEPENDENCIES_JSON: ${{ steps.dependabot-metadata.outputs.updated-dependencies-json }}
+        with:
+          migration-script: |
+            """Sync grpc/protobuf pins and runtime ranges from Dependabot metadata."""
+
+            import json
+            import os
+            import re
+            import sys
+            from pathlib import Path
+
+
+            PYPROJECT = Path("pyproject.toml")
+            TRACKED_DEPS = ("protobuf", "grpcio-tools", "grpcio")
+            RUNTIME_DEPS = ("protobuf", "grpcio")
+
+
+            def fail(message: str) -> None:
+                print(f"ERROR: {message}", file=sys.stderr)
+                sys.exit(1)
+
+
+            def major(version: str) -> int:
+                match = re.match(r"v?(\d+)(?:[.+-]|$)", version.strip())
+                if match is None:
+                    fail(f"could not parse a major version from {version!r}")
+                return int(match.group(1))
+
+
+            def dependency_versions() -> dict[str, str]:
+                raw = os.environ.get("UPDATED_DEPENDENCIES_JSON", "")
+                if not raw:
+                    fail("UPDATED_DEPENDENCIES_JSON is empty")
+
+                try:
+                    dependencies = json.loads(raw)
+                except json.JSONDecodeError as exc:
+                    fail(f"failed to parse UPDATED_DEPENDENCIES_JSON: {exc}")
+
+                if not isinstance(dependencies, list):
+                    fail("UPDATED_DEPENDENCIES_JSON must be an array")
+
+                versions: dict[str, str] = {}
+                for dependency in dependencies:
+                    if not isinstance(dependency, dict):
+                        fail("UPDATED_DEPENDENCIES_JSON contains a non-object item")
+                    name = dependency.get("dependencyName")
+                    if name not in TRACKED_DEPS:
+                        continue
+                    version = dependency.get("newVersion")
+                    if not isinstance(version, str) or not version:
+                        fail(f"missing newVersion for {name!r}")
+                    versions[name] = version
+
+                if not versions:
+                    fail("no grpc/protobuf dependency metadata found")
+
+                return versions
+
+
+            def replace_once(text: str, pattern: str, repl, what: str) -> tuple[str, int]:
+                text, count = re.subn(pattern, repl, text, count=1)
+                if count != 1:
+                    fail(f"expected exactly one {what} entry")
+                return text, count
+
+
+            def replace_range(text: str, name: str, version: str) -> tuple[str, int]:
+                pattern = rf'("{re.escape(name)}\s*>=\s*)([^,"]+)(\s*,\s*<\s*)([^"]+)(")'
+                new_limit_major: int | None = None
+
+                def repl(match: re.Match[str]) -> str:
+                    nonlocal new_limit_major
+                    old_floor = match.group(2).strip()
+                    old_limit = match.group(4).strip()
+                    old_floor_major = major(old_floor)
+                    old_limit_major = major(old_limit)
+                    new_major = major(version)
+                    if new_major < old_floor_major:
+                        fail(f"refusing to downgrade {name} from {old_floor} to {version}")
+                    new_limit_major = old_limit_major + new_major - old_floor_major
+                    return f"{match.group(1)}{version}{match.group(3)}{new_limit_major}{match.group(5)}"
+
+                text, count = replace_once(text, pattern, repl, f"{name} runtime range")
+                if new_limit_major is None:
+                    fail(f"could not compute the new {name} upper bound")
+
+                comment_pattern = (
+                    rf'("{re.escape(name)}\s*>=\s*{re.escape(version)}'
+                    rf'\s*,\s*<\s*{new_limit_major}"\s*,\s*'
+                    rf'#\s*Do not widen beyond\s*)\d+(!)'
+                )
+                text = re.sub(
+                    comment_pattern,
+                    rf"\g<1>{new_limit_major}\2",
+                    text,
+                    count=1,
+                )
+                return text, count
+
+
+            def main() -> None:
+                if not PYPROJECT.exists():
+                    fail("pyproject.toml not found")
+
+                text = PYPROJECT.read_text(encoding="utf-8")
+                versions = dependency_versions()
+                replacements = 0
+
+                for name in RUNTIME_DEPS:
+                    version = versions.get(name)
+                    if version is None:
+                        continue
+                    text, count = replace_range(text, name, version)
+                    replacements += count
+
+                if replacements == 0:
+                    print("No grpc/protobuf runtime constraints to update.")
+                    return
+
+                PYPROJECT.write_text(text, encoding="utf-8")
+                print(f"Updated pyproject.toml with {replacements} grpc/protobuf constraint(s).")
+
+
+            main()
+          token: ${{ steps.create-app-token.outputs.token }}
+          sign-commits: "true"
+          auto-merged-label: "tool:auto-merged"
+          migrated-label: "tool:grpc:migration:executed"
+          intervention-pending-label: "tool:grpc:migration:intervention-pending"
+          intervention-done-label: "tool:grpc:migration:intervention-done"


### PR DESCRIPTION
Dependabot fails to update grpc/protobuf dependencies correctly, as it limits itself to update build dependencies, but leave the runtime dependencies untouched.

This doesn't work because protobuf/grpc need to be generated with a version that is equals or older to the runtime version, so if we only bump the build dependency, a project might still depend on an older version at runtime, and we should not allow that.

This PR adds an auto-migration workflow to fix this, while also ensuring the major version for protobuf is bumped accordingly when a major version bump occurs.

This is an experimental change. If this work the upgrade script will be moved to a separate repository and the workflow added to repo-config.
