### PR TITLE
Add new definition of balancing group and move market location definition to the `grid` submodule from `market`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,7 +11,6 @@ v1alpha8 and moved market location definition to the `grid` submodule.
 
 - Added `BalancingGroup` to 
   "frequenz/api/common/v1alpha8/grid/balancing_group.proto"
-- Moved `MarketLocation` from market to grid submodule
 
 ## Bug Fixes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,16 +2,16 @@
 
 ## Summary
 
-This release includes addition of new definitions of market area and market 
-locations in v1alpha8.
+This release includes addition a new definition of balancing group in 
+v1alpha8 and moved market location definition to the `grid` submodule.
 
 ## Upgrading
 
 ## New Features
 
-- Added `MarketLocationIdType`, `MarketLocationIdValue`, `MarketLocationId` and 
-  `MarketLocationSelector` to "frequenz/api/common/v1alpha8/market/market_location.proto"
-- Added `MarketArea` to "frequenz/api/common/v1alpha8/market/market_area.proto"
+- Added `BalancingGroup` to 
+  "frequenz/api/common/v1alpha8/grid/balancing_group.proto"
+- Moved `MarketLocation` from market to grid submodule
 
 ## Bug Fixes
 

--- a/proto/frequenz/api/common/v1alpha8/grid/balancing_group.proto
+++ b/proto/frequenz/api/common/v1alpha8/grid/balancing_group.proto
@@ -1,0 +1,24 @@
+// Frequenz definitions balancing groups.
+//
+// Copyright 2025 Frequenz Energy-as-a-Service GmbH
+//
+// Licensed under the MIT License (the "License");
+// you may not use this file except in compliance with the License.
+
+syntax = "proto3";
+
+package frequenz.api.common.v1alpha8.grid;
+
+import "frequenz/api/common/v1alpha8/grid/delivery_area.proto";
+
+// Identifies a balancing group by its market code.
+//
+// This message identifies the balancing group itself. It does not include the
+// delivery area in which the balancing group is used.
+message BalancingGroup {
+  // The balancing group code.
+  string code = 1;
+
+  // The type of market code used to identify the balancing group.
+  EnergyMarketCodeType code_type = 2;
+}

--- a/proto/frequenz/api/common/v1alpha8/grid/market_location.proto
+++ b/proto/frequenz/api/common/v1alpha8/grid/market_location.proto
@@ -7,7 +7,7 @@
 
 syntax = "proto3";
 
-package frequenz.api.common.v1alpha8.market;
+package frequenz.api.common.v1alpha8.grid;
 
 import "frequenz/api/common/v1alpha8/market/market_area.proto";
 
@@ -134,7 +134,7 @@ message MarketLocationId {
 // Identifies a Market Location.
 message MarketLocationSelector {
   // Regulatory jurisdiction in which this Market Location is registered.
-  MarketArea market_area = 1;
+  frequenz.api.common.v1alpha8.market.MarketArea market_area = 1;
 
   // Official market identifier (MaLo-ID, MPAN, ESI-ID, ...).
   MarketLocationId market_location_id = 2;


### PR DESCRIPTION
* Add new definition of balancing group in v1alpha8
* moved market location definition to the `grid` submodule