### PR TITLE
Document Bounds ordering

### DIFF
--- a/proto/frequenz/api/common/v1alpha8/metrics/bounds.proto
+++ b/proto/frequenz/api/common/v1alpha8/metrics/bounds.proto
@@ -12,6 +12,7 @@ package frequenz.api.common.v1alpha8.metrics;
 
 // A set of lower and upper bounds for any metric.
 // The units of the bounds are always the same as the related metric.
+// If both are set, `lower` must be less than or equal to `upper`.
 message Bounds {
   // The lower bound.
   // If absent, there is no lower bound.


### PR DESCRIPTION
`frequenz.api.common.v1alpha8.metrics.Bounds` now documents the ordering rule for paired bounds: when both endpoints are present, `lower` must be `<= upper`. This makes the contract explicit for producers and consumers of the v1alpha8 API.