### PR TITLE
Document lifetime ordering rule

### DIFF
--- a/proto/frequenz/api/common/v1alpha8/microgrid/lifetime.proto
+++ b/proto/frequenz/api/common/v1alpha8/microgrid/lifetime.proto
@@ -37,5 +37,7 @@ message Lifetime {
   // Optional timestamp when the asset's operational activity ceased.
   // If not set, the asset is considered to be in operation indefinitely into
   // the future.
+  // When both timestamps are set, `start_timestamp` should be less than or
+  // equal to `end_timestamp`.
   google.protobuf.Timestamp end_timestamp = 2;
 }


### PR DESCRIPTION
`Lifetime` in `v1alpha8` now documents the expected timestamp ordering when both bounds are present: the start must not come after the end. This clarifies the contract for producers and consumers without changing the schema.
